### PR TITLE
Fix for issue #2213

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,6 +10,7 @@ class dns(
     $vardir = $dns::params::vardir,
     $namedservicename = $dns::params::namedservicename,
     $zonefilepath = $dns::params::zonefilepath,
+    $localzonepath = $dns::params::localzonepath,
     $forwarders = $dns::params::forwarders
 ) inherits dns::params {
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,6 +5,7 @@ class dns::params {
         $vardir             = '/var/cache/bind'
         $optionspath        = "${dnsdir}/named.conf.options"
         $zonefilepath       = "${vardir}/zones"
+        $localzonepath      = "${dnsdir}/zones.rfc1918"
         $dns_server_package = 'bind9'
         $namedservicename   = 'bind9'
         $user               = 'bind'
@@ -15,6 +16,7 @@ class dns::params {
         $vardir             = '/var/named'
         $optionspath        = '/etc/named/options.conf'
         $zonefilepath       = "${vardir}/dynamic"
+        $localzonepath      = "${dnsdir}/named.rfc1912.zones"
         $dns_server_package = 'bind'
         $namedservicename   = 'named'
         $user               = 'named'

--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -10,7 +10,7 @@ options  {
 	include "<%= optionspath %>";
 };
 
-include "/etc/named.rfc1912.zones";
+include "<%= localzonepath %>";
 
 // Public view read by Server Admin
 include "<%= publicviewpath %>";


### PR DESCRIPTION
The path to the localhost TLDs and address zones file was incorrect for Debian based distros and prevented the named process from starting. This resolves that issue.
