### PR TITLE
Ensure changed concat files are Filebuckted

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A puppet module to setup bind for The Foreman
 
 ## Dependencies
 
-* Reworked Concat module (https://github.com/GregSutcliffe/puppet-concat)
+* Native-type Concat module (https://github.com/onyxpoint/pupmod-concat)
 
 ToDo
 ----

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,87 +1,91 @@
 class dns(
-    $namedconf_path = $dns::params::namedconf_path,
-    $dnsdir = $dns::params::dnsdir,
-    $dns_server_package = $dns::params::dns_server_package,
-    $rndckeypath = $dns::params::rndckeypath,
-    $rndc_alg = $dns::params::rndc_alg,
-    $rndc_secret = $dns::params::rndc_secret,
-    $optionspath = $dns::params::optionspath,
-    $publicviewpath = $dns::params::publicviewpath,
-    $vardir = $dns::params::vardir,
-    $namedservicename = $dns::params::namedservicename,
-    $zonefilepath = $dns::params::zonefilepath,
-    $localzonepath = $dns::params::localzonepath,
-    $forwarders = $dns::params::forwarders
+  $namedconf_path = $dns::params::namedconf_path,
+  $dnsdir = $dns::params::dnsdir,
+  $dns_server_package = $dns::params::dns_server_package,
+  $rndckeypath = $dns::params::rndckeypath,
+  $rndc_alg = $dns::params::rndc_alg,
+  $rndc_secret = $dns::params::rndc_secret,
+  $optionspath = $dns::params::optionspath,
+  $publicviewpath = $dns::params::publicviewpath,
+  $vardir = $dns::params::vardir,
+  $namedservicename = $dns::params::namedservicename,
+  $zonefilepath = $dns::params::zonefilepath,
+  $localzonepath = $dns::params::localzonepath,
+  $forwarders = $dns::params::forwarders
 ) inherits dns::params {
 
-    package { 'dns':
-      ensure => installed,
-      name   => $dns_server_package,
-    }
+  package { 'dns':
+    ensure => installed,
+    name   => $dns_server_package,
+  }
 
-    group { $dns::params::group:
-      require => Package['dns']
-    }
+  group { $dns::params::group:
+    require => Package['dns']
+  }
 
-    File {
-        require => Package['dns'],
-    }
+  File {
+    require => Package['dns'],
+  }
 
-    file {
-        $namedconf_path:
-            owner   => root,
-            group   => $dns::params::group,
-            mode    => '0640',
-            require => Package['dns'],
-            notify  => Service[$namedservicename],
-            content => template('dns/named.conf.erb');
-        $optionspath:
-            owner   => root,
-            group   => $dns::params::group,
-            mode    => '0640',
-            notify  => Service[$namedservicename],
-            content => template('dns/options.conf.erb');
-        $zonefilepath:
-            ensure  => directory,
-            owner   => $dns::params::user,
-            group   => $dns::params::group,
-            mode    => '0640';
-        "${vardir}/puppetstore":
-            ensure  => directory,
-            group   => $dns::params::group,
-            mode    => '0640';
-    }
+  concat_build { 'dns_zones':
+    order  => ['*.dns'],
+  }
 
-    concat_build { 'dns_zones':
-      order  => ['*.dns'],
-      target => $publicviewpath,
-      notify => Service[$namedservicename],
-    }
+  concat_fragment { 'dns_zones+01-header.dns':
+    content => ' ',
+  }
 
-    concat_fragment { 'dns_zones+01-header.dns':
-      content => ' ',
-    }
-
-    service {
-        $namedservicename:
-            ensure     => running,
-            enable     => true,
-            hasstatus  => true,
-            hasrestart => true,
-            require    => Package['dns'];
-    }
-
-    exec { 'create-rndc.key':
-      command => "/usr/sbin/rndc-confgen -r /dev/urandom -a -c ${rndckeypath}",
-      cwd     => '/tmp',
-      creates => $rndckeypath,
-      require => Package['dns'],
-    }
-
-    file { $rndckeypath:
-      owner   => 'root',
+  file {
+    $namedconf_path:
+      owner   => root,
       group   => $dns::params::group,
       mode    => '0640',
-      require => Exec['create-rndc.key'],
-    }
+      notify  => Service[$namedservicename],
+      content => template('dns/named.conf.erb');
+    $publicviewpath:
+      owner   => root,
+      group   => $dns::params::group,
+      mode    => '0640',
+      require => Concat_build['dns_zones'],
+      notify  => Service[$namedservicename],
+      source  => concat_output('dns_zones');
+    $optionspath:
+      owner   => root,
+      group   => $dns::params::group,
+      mode    => '0640',
+      notify  => Service[$namedservicename],
+      content => template('dns/options.conf.erb');
+    $zonefilepath:
+      ensure  => directory,
+      owner   => $dns::params::user,
+      group   => $dns::params::group,
+      mode    => '0640';
+    "${vardir}/puppetstore":
+      ensure  => directory,
+      group   => $dns::params::group,
+      mode    => '0640';
+  }
+
+  service {
+    $namedservicename:
+      ensure     => running,
+      enable     => true,
+      hasstatus  => true,
+      hasrestart => true,
+      require    => Package['dns'];
+  }
+
+  exec { 'create-rndc.key':
+    command => "/usr/sbin/rndc-confgen -r /dev/urandom -a -c ${rndckeypath}",
+    cwd     => '/tmp',
+    creates => $rndckeypath,
+    require => Package['dns'],
+  }
+
+  file { $rndckeypath:
+    owner   => 'root',
+    group   => $dns::params::group,
+    mode    => '0640',
+    require => Exec['create-rndc.key'],
+  }
 }


### PR DESCRIPTION
By dropping the Target parameter from the build object, the final concat object is only written to $vardir/concat - we can then source that in the File object to get the old File bucketed

Depends on the concat module change in foreman-installer.
