### PR TITLE
Remove dependency.

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,4 +1,2 @@
 name    'theforeman-dns'
 version '1.0.1'
-dependency 'ripienaar-concat', '20100507'
-


### PR DESCRIPTION
This dependency explodes with librarian-puppet.  We should revisit these after uploading the installer modules to the forge.
