### PR TITLE
Task create-rndc was being executed every run

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -36,6 +36,7 @@ class dns::config {
 
   exec { 'create-rndc.key':
     command => "/usr/sbin/rndc-confgen -r /dev/urandom -a -c ${dns::rndckeypath}",
+    creates => $dns::rndckeypath,
   } ->
   file { $dns::rndckeypath:
     owner   => 'root',


### PR DESCRIPTION
```
[root@foreman ~]# md5sum < /etc/rndc.key
3b5618ac28e19da630021a38d06a0d14  -

[root@foreman ~]# foreman-installer -v 
[ INFO 2013-10-24 12:38:24 verbose] Running validation checks
[ INFO 2013-10-24 12:38:24 verbose]  Loading facts in postgres_default_version
[ INFO 2013-10-24 12:38:24 verbose]  Loading facts in root_home
[ INFO 2013-10-24 12:38:24 verbose]  Loading facts in pe_version
[ INFO 2013-10-24 12:38:24 verbose]  Loading facts in facter_dot_d
[ INFO 2013-10-24 12:38:24 verbose]  Loading facts in puppet_vardir
[ INFO 2013-10-24 12:38:24 verbose]  Loading facts in concat_basedir
[ INFO 2013-10-24 12:38:30 verbose] ''
[ INFO 2013-10-24 12:38:35 verbose]  Applying configuration version '1382611104'
[ WARN 2013-10-24 12:38:36 verbose]  /Stage[main]/Dns::Config/Exec[create-rndc.key]/returns: executed successfully
[ INFO 2013-10-24 12:38:36 verbose]  /Stage[main]/Dns::Config/Exec[create-rndc.key]: Scheduling refresh of Service[named]
[ WARN 2013-10-24 12:38:46 verbose]  /Stage[main]/Dns::Service/Service[named]: Triggered 'refresh' from 1 events
[ WARN 2013-10-24 12:38:47 verbose]  Finished catalog run in 17.55 seconds
[ INFO 2013-10-24 12:38:47 verbose] Puppet has finished, bye!
  Success!
  * Foreman is running at https://foreman.virtual.lan
      Default credentials are 'admin:changeme'
  * Foreman Proxy is running at https://foreman.virtual.lan:8443
  * Puppetmaster is running at port 8140
  The full log is at /var/log/foreman-installer/foreman-installer.log

[root@foreman ~]# md5sum < /etc/rndc.key
3337cb80f92f13fb63cf9e41a7210737  -

```
