### PR TITLE
Do not restart the bind server at every puppet run

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -36,6 +36,7 @@ class dns::config {
 
   exec { 'create-rndc.key':
     command => "/usr/sbin/rndc-confgen -r /dev/urandom -a -c ${dns::rndckeypath}",
+    unless  => "/usr/bin/stat ${dns::rndckeypath}",
   } ->
   file { $dns::rndckeypath:
     owner   => 'root',


### PR DESCRIPTION
Before this PR, the rndc key was regenerated at each puppet run,
even if it existed, notifying the named service to restart.
So at every puppet run, the named service was restarting. This PR
add an unless check for the rndc.key exec creation.
