### PR TITLE
Use https

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,6 @@
 fixtures:
   repositories:
-    concat_native:    'git://github.com/theforeman/puppet-concat'
+    concat_native:    'https://github.com/theforeman/puppet-concat'
 
   symlinks:
     dns: "#{source_dir}"


### PR DESCRIPTION
HTTPS at least sometimes works over proxies in corporate networks while
git:// surely doesn't.
