### PR TITLE
Adding SRV record for foreman

### DIFF
--- a/templates/zone.header.erb
+++ b/templates/zone.header.erb
@@ -8,6 +8,9 @@ $TTL <%= @ttl %>
 )
 
 @ IN NS <%= @soa %>.
+
+_x-foreman._tcp IN SRV 0 5 443 <%= @soa %>.
+
 <% if ! @reverse %>
 <%= @soa %>. IN A <%= @soaip %>
 <% end %>


### PR DESCRIPTION
Guys, I am trying to put this line in each zone which points to foreman itself:

  _foreman._tcp.virtual.lan. 86400 IN SRV 0 5 443 foreman.virtual.lan.

Is this correct? Can you help me testing it? I don't understand how this works.
This is open for discussion.
