### PR TITLE
Slave support

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,7 @@
 fixtures:
   repositories:
     concat_native:    'https://github.com/theforeman/puppet-concat'
+    stdlib:           'https://github.com/puppetlabs/puppetlabs-stdlib.git'
 
   symlinks:
     dns: "#{source_dir}"

--- a/.sync.yml
+++ b/.sync.yml
@@ -1,0 +1,4 @@
+---
+spec/spec_helper.rb:
+  requires:
+    - lib/module_spec_helper

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -1,46 +1,46 @@
 # Define new zone for the dns
 define dns::zone (
-    $zonetype='master',
-    $soa='',
-    $reverse=false,
-    $ttl='10800',
-    $soaip='',
+    $zonetype = 'master',
+    $soa = $::fqdn,
+    $reverse = false,
+    $ttl = '10800',
+    $soaip = $::ipaddress,
     $refresh = 86400,
     $update_retry = 3600,
     $expire = 604800,
     $negttl = 3600,
-    $zonefilepath     = $dns::params::zonefilepath,
-    $namedservicename     = $dns::params::namedservicename,
+    $serial = 1,
     $masters = [],
-    $allow_transfer = []
+    $allow_transfer = [],
+    $zone = $title,
+    $contact = "root.${title}.",
+    $filename = "db.${title}",
 ) {
-  $contact = "root.${name}."
-  $serial = 1
 
-  if ! defined(Class[dns]) {
-    class { 'dns':
-      zonefilepath     => $zonefilepath,
-      namedservicename => $namedservicename
-    }
+  validate_bool($reverse)
+  validate_array($masters, $allow_transfer)
+
+  # Validate that the value for soa is within the zone
+  $soa_parts    = split($soa, '[.]')
+  $soa_hostname = $soa_parts[0]
+  if $soa != "${soa_hostname}.${zone}" and ! $reverse {
+    fail('soa must be within the defined zone.')
   }
 
-  include dns::params
+  include dns
 
-  $zone             = $name
-  $filename         = "db.${zone}"
-  $zonefilename     = "${zonefilepath}/${filename}"
+  $zonefilename = "${dns::zonefilepath}/${filename}"
 
   concat_fragment { "dns_zones+10_${zone}.dns":
     content => template('dns/named.zone.erb'),
   }
 
   file { $zonefilename:
-    owner   => $dns::params::user,
-    group   => $dns::params::group,
-    mode    => '0640',
+    owner   => $dns::user,
+    group   => $dns::group,
+    mode    => '0644',
     content => template('dns/zone.header.erb'),
-    require => File[$zonefilepath],
     replace => false,
-    notify  => Service[$namedservicename],
+    notify  => Service[$dns::namedservicename],
   }
 }

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -10,7 +10,9 @@ define dns::zone (
     $expire = 604800,
     $negttl = 3600,
     $zonefilepath     = $dns::params::zonefilepath,
-    $namedservicename     = $dns::params::namedservicename
+    $namedservicename     = $dns::params::namedservicename,
+    $masters = [],
+    $allow_transfer = []
 ) {
   $contact = "root.${name}."
   $serial = 1
@@ -33,6 +35,9 @@ define dns::zone (
   }
 
   file { $zonefilename:
+    owner   => $dns::params::user,
+    group   => $dns::params::group,
+    mode    => '0640',
     content => template('dns/zone.header.erb'),
     require => File[$zonefilepath],
     replace => false,

--- a/spec/defines/dns_zone_spec.rb
+++ b/spec/defines/dns_zone_spec.rb
@@ -1,0 +1,140 @@
+require 'spec_helper'
+
+describe 'dns::zone' do
+
+  let(:facts) do
+    {
+      :osfamily   => 'RedHat',
+      :fqdn       => 'puppetmaster.example.com',
+      :clientcert => 'puppetmaster.example.com',
+      :ipaddress  => '192.168.1.1'
+    }
+  end
+
+  let(:title) { "example.com" }
+
+  it "should have valid zone configuration" do
+    verify_concat_fragment_exact_contents(subject, 'dns_zones+10_example.com.dns', [
+      'zone "example.com" {',
+      '    type master;',
+      '    file "/var/named/dynamic/db.example.com";',
+      '    update-policy {',
+      '            grant rndc-key zonesub ANY;',
+      '    };',
+      '};',
+    ])
+  end
+
+  it "should create zone file" do
+    should contain_file('/var/named/dynamic/db.example.com').with({
+      :owner    => 'named',
+      :group    => 'named',
+      :mode     => '0644',
+      :replace  => 'false',
+      :notify   => 'Service[named]',
+    })
+  end
+
+  it "should have valid zone file contents" do
+    verify_exact_contents(subject, '/var/named/dynamic/db.example.com', [
+      '$TTL 10800',
+      '@ IN SOA puppetmaster.example.com. root.example.com. (',
+      '	1	;Serial',
+      '	86400	;Refresh',
+      '	3600	;Retry',
+      '	604800	;Expire',
+      '	3600	;Negative caching TTL',
+      ')',
+      '@ IN NS puppetmaster.example.com.',
+      'puppetmaster.example.com. IN A 192.168.1.1',
+    ])
+  end
+
+  context 'when reverse => true' do
+    let(:title) { '1.168.192.in-addr.arpa' }
+    let(:params) {{ :reverse => true }}
+
+    it "should have valid zone file contents" do
+      verify_exact_contents(subject, '/var/named/dynamic/db.1.168.192.in-addr.arpa', [
+        '$TTL 10800',
+        '@ IN SOA puppetmaster.example.com. root.1.168.192.in-addr.arpa. (',
+        '	1	;Serial',
+        '	86400	;Refresh',
+        '	3600	;Retry',
+        '	604800	;Expire',
+        '	3600	;Negative caching TTL',
+        ')',
+        '@ IN NS puppetmaster.example.com.',
+      ])
+    end
+  end
+
+  context 'when allow_transfer defined' do
+    let(:params) {{ :allow_transfer => ['192.168.1.2'] }}
+
+    it "should have valid zone configuration with allow-transfer" do
+      verify_concat_fragment_exact_contents(subject, 'dns_zones+10_example.com.dns', [
+        'zone "example.com" {',
+        '    type master;',
+        '    file "/var/named/dynamic/db.example.com";',
+        '    update-policy {',
+        '            grant rndc-key zonesub ANY;',
+        '    };',
+        '    allow-transfer { 192.168.1.2; };',
+        '};',
+      ])
+    end
+
+    context 'when allow_transfer with multiple values' do
+      let(:params) {{ :allow_transfer => ['192.168.1.2', '192.168.1.3'] }}
+
+      it "should have valid zone configuration with allow-transfer" do
+        verify_concat_fragment_exact_contents(subject, 'dns_zones+10_example.com.dns', [
+          'zone "example.com" {',
+          '    type master;',
+          '    file "/var/named/dynamic/db.example.com";',
+          '    update-policy {',
+          '            grant rndc-key zonesub ANY;',
+          '    };',
+          '    allow-transfer { 192.168.1.2; 192.168.1.3; };',
+          '};',
+        ])
+      end
+    end
+  end
+
+  context 'when zonetype => slave' do
+    let(:params) {{ :zonetype => 'slave', :masters  => ['192.168.1.1'] }}
+
+    it "should have valid slave zone configuration" do
+      verify_concat_fragment_exact_contents(subject, 'dns_zones+10_example.com.dns', [
+        'zone "example.com" {',
+        '    type slave;',
+        '    file "/var/named/dynamic/db.example.com";',
+        '    masters { 192.168.1.1; };',
+        '};',
+      ])
+    end
+
+    context 'when multiple masters defined' do
+      let(:params) {{ :zonetype => 'slave', :masters  => ['192.168.1.1', '192.168.1.2'] }}
+
+      it "should have valid slave zone configuration" do
+        verify_concat_fragment_exact_contents(subject, 'dns_zones+10_example.com.dns', [
+          'zone "example.com" {',
+          '    type slave;',
+          '    file "/var/named/dynamic/db.example.com";',
+          '    masters { 192.168.1.1; 192.168.1.2; };',
+          '};',
+        ])
+      end
+    end
+  end
+
+  context 'when soa is not a part of the zone' do
+    let(:params) {{ :soa => 'foo.example.tld', :zone => 'example.com' }}
+    it "should raise an error" do
+      expect { should compile }.to raise_error(/soa must be within the defined zone/)
+    end
+  end
+end

--- a/spec/lib/module_spec_helper.rb
+++ b/spec/lib/module_spec_helper.rb
@@ -1,0 +1,14 @@
+def verify_concat_fragment_contents(subject, title, expected_lines)
+  content = subject.resource('concat_fragment', title).send(:parameters)[:content]
+  (content.split("\n") & expected_lines).should == expected_lines
+end
+
+def verify_concat_fragment_exact_contents(subject, title, expected_lines)
+  content = subject.resource('concat_fragment', title).send(:parameters)[:content]
+  content.split(/\n/).reject { |line| line =~ /(^#|^$|^\s+#)/ }.should == expected_lines
+end
+
+def verify_exact_contents(subject, title, expected_lines)
+  content = subject.resource('file', title).send(:parameters)[:content]
+  content.split(/\n/).reject { |line| line =~ /(^#|^$|^\s+#)/ }.should == expected_lines
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 #   https://github.com/theforeman/foreman-installer-modulesync
 
 require 'puppetlabs_spec_helper/module_spec_helper'
+require 'lib/module_spec_helper'
 
 # Workaround for no method in rspec-puppet to pass undef through :params
 class Undef

--- a/templates/named.zone.erb
+++ b/templates/named.zone.erb
@@ -1,17 +1,15 @@
 zone "<%= @zone %>" {
-  type <%= @zonetype %>;
-  file "<%= @zonefilename %>";
-<% if @zonetype == 'master' -%>    
-  update-policy {
-    grant rndc-key zonesub ANY;
-  };
-<% else -%>
-<%- if @allow_transfer -%>
-  allow-transfer { <% allow_transfer.each do |node| %><%= node %>; <% end %>};
+    type <%= @zonetype %>;
+    file "<%= @zonefilename %>";
+<% if @zonetype == 'master' -%>
+    update-policy {
+            grant rndc-key zonesub ANY;
+    };
 <% end -%>
-<% if @masters -%>
-  masters { <% masters.each do |node| %><%= node %>; <% end %>};
+<% unless @allow_transfer.empty? -%>
+    allow-transfer { <%= @allow_transfer.join('; ') %>; };
 <% end -%>
+<% unless @masters.empty? -%>
+    masters { <%= @masters.join('; ') %>; };
 <% end -%>
 };
-# vim: set et sw=2 ts=2 ft=named:

--- a/templates/named.zone.erb
+++ b/templates/named.zone.erb
@@ -1,7 +1,17 @@
 zone "<%= @zone %>" {
-    type <%= @zonetype %>;
-    file "<%= @zonefilename %>";
-    update-policy {
-            grant rndc-key zonesub ANY;
-    };
+  type <%= @zonetype %>;
+  file "<%= @zonefilename %>";
+<% if @zonetype == 'master' -%>    
+  update-policy {
+    grant rndc-key zonesub ANY;
+  };
+<% else -%>
+<%- if @allow_transfer -%>
+  allow-transfer { <% allow_transfer.each do |node| %><%= node %>; <% end %>};
+<% end -%>
+<% if @masters -%>
+  masters { <% masters.each do |node| %><%= node %>; <% end %>};
+<% end -%>
+<% end -%>
 };
+# vim: set et sw=2 ts=2 ft=named:


### PR DESCRIPTION
This is an extension to #24 

Commit message:

    Add support for master-slave configuration

    This also changes the use of defining the "dns" class inside the dns::zone defined type.
    Instead the dns class is included and the parameters "zonefilepath" and "namedservicename" pull their values from
    the dns class if left as undef.

    Initial work came from PR #24.  This varies from that pull request in the following ways

    * allow-transfer is not inside the "if master" condition
    * A few syntax errors corrected
    * Use "join" to generate values for allow-transfer and masters

Also wanted to add I tried to keep my changes that do not relate to functionality of master-slave to a minimum.  Defining parameter defaults in `dns::zone` that came from `dns::params` was causing problems with unit tests without setting a pre_condition.  Rather than use a pre_condition in the unit tests I removed the `dns` class declaration from `dns::zone` and instead us the safer `include`.