### PR TITLE
Refactor dns::zone

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,7 @@
 fixtures:
   repositories:
     concat_native:    'https://github.com/theforeman/puppet-concat'
+    stdlib:           'https://github.com/puppetlabs/puppetlabs-stdlib.git'
 
   symlinks:
     dns: "#{source_dir}"

--- a/.sync.yml
+++ b/.sync.yml
@@ -1,0 +1,4 @@
+---
+spec/spec_helper.rb:
+  requires:
+    - lib/module_spec_helper

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,20 +1,20 @@
 # Install, configure and start dns service
 class dns(
-  $namedconf_path = $dns::params::namedconf_path,
-  $dnsdir = $dns::params::dnsdir,
-  $dns_server_package = $dns::params::dns_server_package,
-  $rndckeypath = $dns::params::rndckeypath,
-  $optionspath = $dns::params::optionspath,
-  $publicviewpath = $dns::params::publicviewpath,
-  $vardir = $dns::params::vardir,
-  $namedservicename = $dns::params::namedservicename,
-  $zonefilepath = $dns::params::zonefilepath,
-  $localzonepath = $dns::params::localzonepath,
-  $forwarders = $dns::params::forwarders,
-  $listen_on_v6 = $dns::params::listen_on_v6
+  $namedconf_path     = $::dns::params::namedconf_path,
+  $dnsdir             = $::dns::params::dnsdir,
+  $dns_server_package = $::dns::params::dns_server_package,
+  $rndckeypath        = $::dns::params::rndckeypath,
+  $optionspath        = $::dns::params::optionspath,
+  $publicviewpath     = $::dns::params::publicviewpath,
+  $vardir             = $::dns::params::vardir,
+  $namedservicename   = $::dns::params::namedservicename,
+  $zonefilepath       = $::dns::params::zonefilepath,
+  $localzonepath      = $::dns::params::localzonepath,
+  $forwarders         = $::dns::params::forwarders,
+  $listen_on_v6       = $::dns::params::listen_on_v6
 ) inherits dns::params {
-  class { 'dns::install': } ~>
-  class { 'dns::config': } ~>
-  class { 'dns::service': } ->
+  class { '::dns::install': } ~>
+  class { '::dns::config': } ~>
+  class { '::dns::service': } ->
   Class['dns']
 }

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -1,20 +1,21 @@
 # Define new zone for the dns
 define dns::zone (
-    $zonetype = 'master',
-    $soa = $::fqdn,
-    $reverse = false,
-    $ttl = '10800',
-    $soaip = $::ipaddress,
-    $refresh = 86400,
-    $update_retry = 3600,
-    $expire = 604800,
-    $negttl = 3600,
-    $serial = 1,
-    $masters = [],
+    $zonetype       = 'master',
+    $soa            = $::fqdn,
+    $reverse        = false,
+    $ttl            = '10800',
+    $soaip          = $::ipaddress,
+    $refresh        = 86400,
+    $update_retry   = 3600,
+    $expire         = 604800,
+    $negttl         = 3600,
+    $serial         = 1,
+    $masters        = [],
     $allow_transfer = [],
-    $zone = $title,
-    $contact = "root.${title}.",
-    $filename = "db.${title}",
+    $zone           = $title,
+    $contact        = "root.${title}.",
+    $zonefilepath   = $::dns::zonefilepath,
+    $filename       = "db.${title}",
 ) {
 
   validate_bool($reverse)
@@ -27,20 +28,19 @@ define dns::zone (
     fail('soa must be within the defined zone.')
   }
 
-  include dns
-
-  $zonefilename = "${dns::zonefilepath}/${filename}"
+  $zonefilename = "${zonefilepath}/${filename}"
 
   concat_fragment { "dns_zones+10_${zone}.dns":
     content => template('dns/named.zone.erb'),
   }
 
   file { $zonefilename:
+    ensure  => file,
     owner   => $dns::user,
     group   => $dns::group,
     mode    => '0644',
     content => template('dns/zone.header.erb'),
     replace => false,
-    notify  => Service[$dns::namedservicename],
+    notify  => Service[$::dns::namedservicename],
   }
 }

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -1,46 +1,46 @@
 # Define new zone for the dns
 define dns::zone (
-    $zonetype='master',
-    $soa='',
-    $reverse=false,
-    $ttl='10800',
-    $soaip='',
+    $zonetype = 'master',
+    $soa = $::fqdn,
+    $reverse = false,
+    $ttl = '10800',
+    $soaip = $::ipaddress,
     $refresh = 86400,
     $update_retry = 3600,
     $expire = 604800,
     $negttl = 3600,
-    $zonefilepath     = $dns::params::zonefilepath,
-    $namedservicename     = $dns::params::namedservicename,
+    $serial = 1,
     $masters = [],
-    $allow_transfer = []
+    $allow_transfer = [],
+    $zone = $title,
+    $contact = "root.${title}.",
+    $filename = "db.${title}",
 ) {
-  $contact = "root.${name}."
-  $serial = 1
 
-  if ! defined(Class[dns]) {
-    class { 'dns':
-      zonefilepath     => $zonefilepath,
-      namedservicename => $namedservicename
-    }
+  validate_bool($reverse)
+  validate_array($masters, $allow_transfer)
+
+  # Validate that the value for soa is within the zone
+  $soa_parts    = split($soa, '[.]')
+  $soa_hostname = $soa_parts[0]
+  if $soa != "${soa_hostname}.${zone}" and ! $reverse {
+    fail('soa must be within the defined zone.')
   }
 
-  include dns::params
+  include dns
 
-  $zone             = $name
-  $filename         = "db.${zone}"
-  $zonefilename     = "${zonefilepath}/${filename}"
+  $zonefilename = "${dns::zonefilepath}/${filename}"
 
   concat_fragment { "dns_zones+10_${zone}.dns":
     content => template('dns/named.zone.erb'),
   }
 
   file { $zonefilename:
-    owner   => $dns::params::user,
-    group   => $dns::params::group,
-    mode    => '0640',
+    owner   => $dns::user,
+    group   => $dns::group,
+    mode    => '0644',
     content => template('dns/zone.header.erb'),
-    require => File[$zonefilepath],
     replace => false,
-    notify  => Service[$namedservicename],
+    notify  => Service[$dns::namedservicename],
   }
 }

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -10,7 +10,9 @@ define dns::zone (
     $expire = 604800,
     $negttl = 3600,
     $zonefilepath     = $dns::params::zonefilepath,
-    $namedservicename     = $dns::params::namedservicename
+    $namedservicename     = $dns::params::namedservicename,
+    $masters = [],
+    $allow_transfer = []
 ) {
   $contact = "root.${name}."
   $serial = 1
@@ -33,6 +35,9 @@ define dns::zone (
   }
 
   file { $zonefilename:
+    owner   => $dns::params::user,
+    group   => $dns::params::group,
+    mode    => '0640',
     content => template('dns/zone.header.erb'),
     require => File[$zonefilepath],
     replace => false,

--- a/spec/defines/dns_zone_spec.rb
+++ b/spec/defines/dns_zone_spec.rb
@@ -13,6 +13,10 @@ describe 'dns::zone' do
 
   let(:title) { "example.com" }
 
+  let :pre_condition do
+    'include dns'
+  end
+
   it "should have valid zone configuration" do
     verify_concat_fragment_exact_contents(subject, 'dns_zones+10_example.com.dns', [
       'zone "example.com" {',

--- a/spec/defines/dns_zone_spec.rb
+++ b/spec/defines/dns_zone_spec.rb
@@ -1,0 +1,140 @@
+require 'spec_helper'
+
+describe 'dns::zone' do
+
+  let(:facts) do
+    {
+      :osfamily   => 'RedHat',
+      :fqdn       => 'puppetmaster.example.com',
+      :clientcert => 'puppetmaster.example.com',
+      :ipaddress  => '192.168.1.1'
+    }
+  end
+
+  let(:title) { "example.com" }
+
+  it "should have valid zone configuration" do
+    verify_concat_fragment_exact_contents(subject, 'dns_zones+10_example.com.dns', [
+      'zone "example.com" {',
+      '    type master;',
+      '    file "/var/named/dynamic/db.example.com";',
+      '    update-policy {',
+      '            grant rndc-key zonesub ANY;',
+      '    };',
+      '};',
+    ])
+  end
+
+  it "should create zone file" do
+    should contain_file('/var/named/dynamic/db.example.com').with({
+      :owner    => 'named',
+      :group    => 'named',
+      :mode     => '0644',
+      :replace  => 'false',
+      :notify   => 'Service[named]',
+    })
+  end
+
+  it "should have valid zone file contents" do
+    verify_exact_contents(subject, '/var/named/dynamic/db.example.com', [
+      '$TTL 10800',
+      '@ IN SOA puppetmaster.example.com. root.example.com. (',
+      '	1	;Serial',
+      '	86400	;Refresh',
+      '	3600	;Retry',
+      '	604800	;Expire',
+      '	3600	;Negative caching TTL',
+      ')',
+      '@ IN NS puppetmaster.example.com.',
+      'puppetmaster.example.com. IN A 192.168.1.1',
+    ])
+  end
+
+  context 'when reverse => true' do
+    let(:title) { '1.168.192.in-addr.arpa' }
+    let(:params) {{ :reverse => true }}
+
+    it "should have valid zone file contents" do
+      verify_exact_contents(subject, '/var/named/dynamic/db.1.168.192.in-addr.arpa', [
+        '$TTL 10800',
+        '@ IN SOA puppetmaster.example.com. root.1.168.192.in-addr.arpa. (',
+        '	1	;Serial',
+        '	86400	;Refresh',
+        '	3600	;Retry',
+        '	604800	;Expire',
+        '	3600	;Negative caching TTL',
+        ')',
+        '@ IN NS puppetmaster.example.com.',
+      ])
+    end
+  end
+
+  context 'when allow_transfer defined' do
+    let(:params) {{ :allow_transfer => ['192.168.1.2'] }}
+
+    it "should have valid zone configuration with allow-transfer" do
+      verify_concat_fragment_exact_contents(subject, 'dns_zones+10_example.com.dns', [
+        'zone "example.com" {',
+        '    type master;',
+        '    file "/var/named/dynamic/db.example.com";',
+        '    update-policy {',
+        '            grant rndc-key zonesub ANY;',
+        '    };',
+        '    allow-transfer { 192.168.1.2; };',
+        '};',
+      ])
+    end
+
+    context 'when allow_transfer with multiple values' do
+      let(:params) {{ :allow_transfer => ['192.168.1.2', '192.168.1.3'] }}
+
+      it "should have valid zone configuration with allow-transfer" do
+        verify_concat_fragment_exact_contents(subject, 'dns_zones+10_example.com.dns', [
+          'zone "example.com" {',
+          '    type master;',
+          '    file "/var/named/dynamic/db.example.com";',
+          '    update-policy {',
+          '            grant rndc-key zonesub ANY;',
+          '    };',
+          '    allow-transfer { 192.168.1.2; 192.168.1.3; };',
+          '};',
+        ])
+      end
+    end
+  end
+
+  context 'when zonetype => slave' do
+    let(:params) {{ :zonetype => 'slave', :masters  => ['192.168.1.1'] }}
+
+    it "should have valid slave zone configuration" do
+      verify_concat_fragment_exact_contents(subject, 'dns_zones+10_example.com.dns', [
+        'zone "example.com" {',
+        '    type slave;',
+        '    file "/var/named/dynamic/db.example.com";',
+        '    masters { 192.168.1.1; };',
+        '};',
+      ])
+    end
+
+    context 'when multiple masters defined' do
+      let(:params) {{ :zonetype => 'slave', :masters  => ['192.168.1.1', '192.168.1.2'] }}
+
+      it "should have valid slave zone configuration" do
+        verify_concat_fragment_exact_contents(subject, 'dns_zones+10_example.com.dns', [
+          'zone "example.com" {',
+          '    type slave;',
+          '    file "/var/named/dynamic/db.example.com";',
+          '    masters { 192.168.1.1; 192.168.1.2; };',
+          '};',
+        ])
+      end
+    end
+  end
+
+  context 'when soa is not a part of the zone' do
+    let(:params) {{ :soa => 'foo.example.tld', :zone => 'example.com' }}
+    it "should raise an error" do
+      expect { should compile }.to raise_error(/soa must be within the defined zone/)
+    end
+  end
+end

--- a/spec/lib/module_spec_helper.rb
+++ b/spec/lib/module_spec_helper.rb
@@ -1,0 +1,14 @@
+def verify_concat_fragment_contents(subject, title, expected_lines)
+  content = catalogue.resource('concat_fragment', title).send(:parameters)[:content]
+  (content.split("\n") & expected_lines).should == expected_lines
+end
+
+def verify_concat_fragment_exact_contents(subject, title, expected_lines)
+  content = catalogue.resource('concat_fragment', title).send(:parameters)[:content]
+  content.split(/\n/).reject { |line| line =~ /(^#|^$|^\s+#)/ }.should == expected_lines
+end
+
+def verify_exact_contents(subject, title, expected_lines)
+  content = catalogue.resource('file', title).send(:parameters)[:content]
+  content.split(/\n/).reject { |line| line =~ /(^#|^$|^\s+#)/ }.should == expected_lines
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 #   https://github.com/theforeman/foreman-installer-modulesync
 
 require 'puppetlabs_spec_helper/module_spec_helper'
+require 'lib/module_spec_helper'
 
 require 'rspec-puppet-facts'
 include RspecPuppetFacts

--- a/templates/named.zone.erb
+++ b/templates/named.zone.erb
@@ -1,17 +1,15 @@
 zone "<%= @zone %>" {
-  type <%= @zonetype %>;
-  file "<%= @zonefilename %>";
-<% if @zonetype == 'master' -%>    
-  update-policy {
-    grant rndc-key zonesub ANY;
-  };
-<% else -%>
-<%- if @allow_transfer -%>
-  allow-transfer { <% allow_transfer.each do |node| %><%= node %>; <% end %>};
+    type <%= @zonetype %>;
+    file "<%= @zonefilename %>";
+<% if @zonetype == 'master' -%>
+    update-policy {
+            grant rndc-key zonesub ANY;
+    };
 <% end -%>
-<% if @masters -%>
-  masters { <% masters.each do |node| %><%= node %>; <% end %>};
+<% unless @allow_transfer.empty? -%>
+    allow-transfer { <%= @allow_transfer.join('; ') %>; };
 <% end -%>
+<% unless @masters.empty? -%>
+    masters { <%= @masters.join('; ') %>; };
 <% end -%>
 };
-# vim: set et sw=2 ts=2 ft=named:

--- a/templates/named.zone.erb
+++ b/templates/named.zone.erb
@@ -1,7 +1,17 @@
 zone "<%= @zone %>" {
-    type <%= @zonetype %>;
-    file "<%= @zonefilename %>";
-    update-policy {
-            grant rndc-key zonesub ANY;
-    };
+  type <%= @zonetype %>;
+  file "<%= @zonefilename %>";
+<% if @zonetype == 'master' -%>    
+  update-policy {
+    grant rndc-key zonesub ANY;
+  };
+<% else -%>
+<%- if @allow_transfer -%>
+  allow-transfer { <% allow_transfer.each do |node| %><%= node %>; <% end %>};
+<% end -%>
+<% if @masters -%>
+  masters { <% masters.each do |node| %><%= node %>; <% end %>};
+<% end -%>
+<% end -%>
 };
+# vim: set et sw=2 ts=2 ft=named:


### PR DESCRIPTION
This now requires the dns class is included when using dns::zone instead of loading it if needed. It also moves more variables to parameters.

Lastly it includes lint cleanups needed for https://github.com/theforeman/puppet-dns/pull/27

This would be a major version bump, but IMHO a good one.