### PR TITLE
remove check if SOA record is in the same zone

### DIFF
--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -21,13 +21,6 @@ define dns::zone (
   validate_bool($reverse)
   validate_array($masters, $allow_transfer)
 
-  # Validate that the value for soa is within the zone
-  $soa_parts    = split($soa, '[.]')
-  $soa_hostname = $soa_parts[0]
-  if $soa != "${soa_hostname}.${zone}" and ! $reverse {
-    fail('soa must be within the defined zone.')
-  }
-
   $zonefilename = "${zonefilepath}/${filename}"
 
   concat_fragment { "dns_zones+10_${zone}.dns":

--- a/spec/defines/dns_zone_spec.rb
+++ b/spec/defines/dns_zone_spec.rb
@@ -135,10 +135,4 @@ describe 'dns::zone' do
     end
   end
 
-  context 'when soa is not a part of the zone' do
-    let(:params) {{ :soa => 'foo.example.tld', :zone => 'example.com' }}
-    it "should raise an error" do
-      expect { should compile }.to raise_error(/soa must be within the defined zone/)
-    end
-  end
 end


### PR DESCRIPTION
I can't find anything in RFCs for that requirement and am even running DNS servers myself with zones that have SOAs in other zones.