### PR TITLE
Add support for managing static records

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,4 @@
+--format documentation
+--color
+--tty
+--backtrace

--- a/README.md
+++ b/README.md
@@ -22,6 +22,23 @@ Zones can be created with the `dns::zone` resource:
 Slaves can also be configured by setting `allow_transfer` in the master's zone
 and setting `zonetype => 'slave'` in the slave's zone.
 
+# Static records
+
+Create 'static' DNS records, such as CNAME records, using the `dns::record` type.
+
+    dns::record { 'foo.example.com':
+      target  => 'vm123.example.com.'
+      type    => 'CNAME'
+    }
+
+**NOTE**: Support for static records is disabled by default, and needs to be enabled
+for each zone separately. For instance: 
+
+    dns::zone { 'example.com':
+      static_records  => true,
+    }
+
+
 # Credits
 
 Based on zleslie-dns, with a lot of the guts ripped out. Thanks

--- a/manifests/record.pp
+++ b/manifests/record.pp
@@ -1,0 +1,61 @@
+# Define new DNS record
+define dns::record (
+  $zone     = undef,
+  $label    = undef,
+  $target   = undef,
+  $type     = undef,
+  $priority = undef,
+  $weight   = undef,
+  $port     = undef,
+  $comment  = ' ',
+) {
+
+  if $target == undef {
+    fail("Failed to define target for record ${title}")
+  }
+  else {
+    validate_string($target)
+  }
+
+  if $type == undef {
+    fail("Failed to define record type for record ${title}")
+  }
+  else {
+    validate_string($type)
+    $dnstype = upcase($type)
+  }
+
+  # if you choose not to override the label or zone attributes  (if you use the
+  # FQDN of the record you want to create, you shouldn't need to), we will 
+  # generate these attributes from the FQDN.
+  if ($label == undef) or ($zone == undef) {
+    $domain_array = split($title, '[.]' )
+    $_label = $domain_array[0]
+    $_zone = join(delete_at($domain_array, 0), '.')
+  } else {
+    $_label = $label
+    $_zone = $zone
+  }
+  
+  if $dnstype =~ /(CNAME|TXT|A|PTR)/ {
+    $line = "${_label} IN ${dnstype} ${target}  ; ${comment}"
+  }
+  elsif $dnstype == 'MX' {
+    validate_integer($priority, 65535, 0)
+    $line = "${_label} IN ${dnstype} ${priority} ${target}  ; ${comment}"
+  }
+  elsif $dnstype == 'SRV' {
+    validate_integer($priority, 65535, 0)
+    validate_integer($weight, 65535, 0)
+    validate_integer($port, 65535, 0)
+    $line = "${_label} IN ${dnstype} ${priority} ${weight} ${port} ${target}  ; ${comment}"
+  }
+  else {
+    fail("Incorrect DNS record type specified for record ${title}")
+  }
+
+  concat_fragment { "dns-static-${_zone}+02content-${title}.dnsstatic":
+    content => $line,
+  }
+
+}

--- a/spec/defines/dns_record_spec.rb
+++ b/spec/defines/dns_record_spec.rb
@@ -60,4 +60,20 @@ describe 'dns::record' do
     it { should_not compile }
   end
 
+  context 'when creating SRV record with non-integer weight' do
+    let(:title) { "badsrv.example.com" }
+    let(:params) {{ 
+      :label  => "_http._tcp.badsrv.example.com.",
+      :target => "vm123.example.com.",
+      :zone   => "example.com",
+      :priority => "10",
+      :weight   => "badweight",
+      :port     => "80",
+      :type   => "SRV",
+      :comment => "Created by vm123",
+    }}
+    
+    it { should_not compile }
+  end
+
 end

--- a/spec/defines/dns_record_spec.rb
+++ b/spec/defines/dns_record_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+describe 'dns::record' do
+
+  let(:facts) do
+    {
+      :osfamily   => 'RedHat',
+      :fqdn       => 'puppetmaster.example.com',
+      :clientcert => 'puppetmaster.example.com',
+      :ipaddress  => '192.168.1.1'
+    }
+  end
+
+  let :pre_condition do
+    'include dns'
+  end
+
+  context 'when creating CNAME record' do
+    let(:title) { "foo.example.com" }
+    let(:params) {{ 
+      :target => "vm123.example.com.",
+      :type   => "CNAME",
+      :comment => "Created by vm123",
+    }}
+  
+    it "should have valid record configuration" do
+      verify_concat_fragment_exact_contents(subject, 'dns-static-example.com+02content-foo.example.com.dnsstatic', [
+        'foo IN CNAME vm123.example.com.  ; Created by vm123',
+      ])
+    end
+  end
+
+  context 'when creating SRV record' do
+    let(:title) { "www.example.com-http-backend1" }
+    let(:params) {{ 
+      :target => "vm123.example.com.",
+      :label  => "_http._tcp.www.example.com.",
+      :zone   => "example.com",
+      :priority => "10",
+      :weight   => "60",
+      :port     => "80",
+      :type   => "SRV",
+      :comment => "Created by vm123",
+    }}
+  
+    it "should have valid record configuration" do
+      verify_concat_fragment_exact_contents(subject, 'dns-static-example.com+02content-www.example.com-http-backend1.dnsstatic', [
+        '_http._tcp.www.example.com. IN SRV 10 60 80 vm123.example.com.  ; Created by vm123',
+      ])
+    end
+  end
+
+  context 'when creating CNAME with blank target' do
+    let(:title) { "badcname.example.com" }
+    let(:params) {{ 
+      :type   => "CNAME",
+      :comment => "Created by vm123",
+    }}
+    
+    it { should_not compile }
+  end
+
+end

--- a/templates/zone.header.erb
+++ b/templates/zone.header.erb
@@ -11,3 +11,6 @@ $TTL <%= @ttl %>
 <% if ! @reverse %>
 <%= @soa %>. IN A <%= @soaip %>
 <% end %>
+<% if @static_records %>
+$INCLUDE <%= @zonefilepath -%>/<%= @filename -%>.static <%= @zone -%>.
+<% end %>


### PR DESCRIPTION
Currently, this module is incapable of managing any records within the zones it creates. Partly, this makes sense because Foreman would be managing the A and PTR records for the hosts it creates. However, users might want to manage other records (A + PTR records for secondary interfaces, CNAME records, TXT records, etcetera), that cannot be easily managed through Foreman. 

I have added functionality to make the above possible by introducing a `dns::record` type, and adding a second file for each zone (db.myzone.tld.static). The `dns::record` type creates a concat fragment that is later collected by the `dns::zone` type. Exported resources are also collected there. 

If you don't want to use this functionality, then the only change will be that the module creates an additional file for each zone: db.myzone.tld.static, which will be empty. Foreman will still manage the db.myzone.tld file. 

Effectively this allows you to manage CNAME records for servers by including them in the Hiera data for the specific host. For example, let's implement the DNS module in a profile: 

```
# 
class profile::dnsserver {
  include dns

  create_resources( 'dns::zone', hiera('dns::zones', {} ))
  create_resources( 'dns::record', hiera('dns::records', {} ))

}
```
and add something to a base profile so that CNAME records from Hiera data (for servers that are not DNS servers) are exported: 
```
class linuxbase::dns_record {

  # collect dns records from hieradata and create exported resources
  $dns_record_defaults = {
    comment => "Created by ${::fqdn}"
  }
  if ! defined( Class['dns'] ) {
    create_resources('@@dns::record', hiera('dns::records', {} ), $dns_record_defaults )
  }

}
```

Then add some Hiera data for the DNS server:
```
---
classes: 
  - 'profile::dnsserver'

dns::zones:
  'example.com':
    zonetype: 'master'
    allow_transfer:
      - 172.16.32.13
    reverse: false
  '8.9.10.in-addr.arpa':
    zonetype: 'master'
    allow_transfer:
      - 172.16.32.13
    reverse: true
```
And for a non-DNS server:
```
---
dns::records:
  'icanhazwebsite.example.com':
    target: 'vm124.example.com.'
    type: 'CNAME'
```

On the DNS server, you will find a file called `db.example.com.static` with the following contents: 
```
..
icanhazwebsite  IN  CNAME  vm124.example.com.  ; Created by vm124.example.com
..
```

The `dns::record` type currently supports the following DNS record types: 
- A
- PTR
- CNAME
- TXT
- SRV
- MX 