### PR TITLE
Add support for managing static records using nsupdate

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,4 @@
+--format documentation
+--color
+--tty
+--backtrace

--- a/README.md
+++ b/README.md
@@ -22,6 +22,23 @@ Zones can be created with the `dns::zone` resource:
 Slaves can also be configured by setting `allow_transfer` in the master's zone
 and setting `zonetype => 'slave'` in the slave's zone.
 
+# Static records
+
+Create 'static' DNS records, such as CNAME records, using the `dns::record` type.
+
+    dns::record { 'foo.example.com':
+      target  => 'vm123.example.com.'
+      type    => 'CNAME'
+    }
+
+**NOTE**: Support for static records is disabled by default, and needs to be enabled
+for each zone separately. For instance: 
+
+    dns::zone { 'example.com':
+      static_records  => true,
+    }
+
+
 # Credits
 
 Based on zleslie-dns, with a lot of the guts ripped out. Thanks

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -32,6 +32,17 @@ class dns::config {
       owner   => $dns::params::user,
       group   => $dns::params::group,
       mode    => '0640';
+    'nsupdate_wrapper':
+      ensure  => file,
+      path    => "${dns::zonefilepath}/nsupdate_wrapper",
+      owner   => $dns::params::user,
+      group   => $dns::params::group,
+      mode    => '0750',
+      content => template('dns/nsupdate_wrapper.erb'),
+      require => [
+        File[$dns::zonefilepath],
+        File[$dns::rndckeypath],
+      ];
   }
 
   exec { 'create-rndc.key':

--- a/manifests/record.pp
+++ b/manifests/record.pp
@@ -1,0 +1,71 @@
+# Define new DNS record
+define dns::record (
+  $ensure   = 'present',
+  $zone     = undef,
+  $label    = undef,
+  $target   = undef,
+  $type     = undef,
+  $priority = undef,
+  $weight   = undef,
+  $port     = undef,
+) {
+
+  if $ensure == 'present' {
+    $action = 'add'
+  }
+  elsif $ensure == 'absent' {
+    $action = 'delete'
+  }
+  else {
+    fail("Incorrect value for ensure for record ${title}")
+  }
+
+  if $target == undef {
+    fail("Failed to define target for record ${title}")
+  }
+  else {
+    validate_string($target)
+  }
+
+  if $type == undef {
+    fail("Failed to define record type for record ${title}")
+  }
+  else {
+    validate_string($type)
+    $dnstype = upcase($type)
+  }
+
+  # if you choose not to override the label or zone attributes  (if you use the
+  # FQDN of the record you want to create, you shouldn't need to), we will 
+  # generate these attributes from the FQDN.
+  if ($label == undef) or ($zone == undef) {
+    $domain_array = split($title, '[.]' )
+    $_label = $domain_array[0]
+    $_zone = join(delete_at($domain_array, 0), '.')
+  } else {
+    $_label = $label
+    $_zone = $zone
+  }
+  
+  if $dnstype =~ /(CNAME|TXT|A|PTR)/ {
+    $line = "update ${action} ${_label}.${_zone}. ${dnstype} ${target}"
+  }
+  elsif $dnstype == 'MX' {
+    validate_integer($priority, 65535, 0)
+    $line = "update ${action} ${_label}.${_zone}. ${dnstype} ${priority} ${target}"
+  }
+  elsif $dnstype == 'SRV' {
+    validate_integer($priority, 65535, 0)
+    validate_integer($weight, 65535, 0)
+    validate_integer($port, 65535, 1)
+    $line = "update ${action} ${_label}.${_zone}. ${dnstype} ${priority} ${weight} ${port} ${target}"
+  }
+  else {
+    fail("Incorrect DNS record type specified for record ${title}")
+  }
+
+  concat_fragment { "dns-static-${_zone}+02content-${title}.dnsstatic":
+    content => $line,
+  }
+
+}

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -16,9 +16,10 @@ define dns::zone (
     $contact        = "root.${title}.",
     $zonefilepath   = $::dns::zonefilepath,
     $filename       = "db.${title}",
+    $static_records = false,
 ) {
 
-  validate_bool($reverse)
+  validate_bool($reverse, $static_records)
   validate_array($masters, $allow_transfer)
 
   $zonefilename = "${zonefilepath}/${filename}"
@@ -36,4 +37,42 @@ define dns::zone (
     replace => false,
     notify  => Service[$::dns::namedservicename],
   }
+
+  if ($static_records == true) and ($zonetype == 'master')  {
+    concat_fragment { "dns-static-${zone}+01header.dnsstatic":
+      content => template('dns/static-header.erb'),
+    }
+  
+    Dns::Record <<| |>> { notify => Concat_build["dns-static-${zone}"] }
+  
+    concat_build { "dns-static-${zone}":
+      order  => [ '*.dnsstatic' ],
+      notify => [
+        #Service[$::dns::namedservicename],
+        File[ "${zonefilename}.nsupdate"],
+      ],
+    }
+  
+    file { "${zonefilename}.nsupdate":
+      ensure  => file,
+      owner   => $dns::user,
+      group   => $dns::group,
+      mode    => '0644',
+      # notify  => Service[$::dns::namedservicename],
+      notify  => Exec["update_dns_${zone}"],
+      source  => concat_output("dns-static-${zone}"),
+      require => Concat_build[ "dns-static-${zone}"],
+    }
+
+    exec { "update_dns_${zone}":
+      command     => "${::dns::zonefilepath}/nsupdate_wrapper ${zone}",
+      refreshonly => true,
+      require     => [
+        File["${zonefilename}.nsupdate"],
+        File['nsupdate_wrapper'],
+        File[$zonefilename],
+      ],
+    }
+  }
+
 }

--- a/spec/classes/dns_init_spec.rb
+++ b/spec/classes/dns_init_spec.rb
@@ -25,6 +25,7 @@ describe 'dns' do
           with_content(%r{include "/etc/named.rfc1912.zones"}).
           with_content(%r{include "/etc/zones.conf"}).
           with_content(%r{include "/etc/named/options.conf"})}
+    it { should contain_file('nsupdate_wrapper') }
     it { should contain_exec('create-rndc.key').
           with_command("/usr/sbin/rndc-confgen -r /dev/urandom -a -c /etc/rndc.key") }
 

--- a/spec/defines/dns_record_spec.rb
+++ b/spec/defines/dns_record_spec.rb
@@ -1,0 +1,75 @@
+require 'spec_helper'
+
+describe 'dns::record' do
+
+  let(:facts) do
+    {
+      :osfamily   => 'RedHat',
+      :fqdn       => 'puppetmaster.example.com',
+      :clientcert => 'puppetmaster.example.com',
+      :ipaddress  => '192.168.1.1'
+    }
+  end
+
+  let :pre_condition do
+    'include dns'
+  end
+
+  context 'when creating CNAME record' do
+    let(:title) { "foo.example.com" }
+    let(:params) {{ 
+      :target => "vm123.example.com.",
+      :type   => "CNAME",
+    }}
+  
+    it "should have valid record configuration" do
+      verify_concat_fragment_exact_contents(subject, 'dns-static-example.com+02content-foo.example.com.dnsstatic', [
+        'update add foo.example.com. CNAME vm123.example.com.',
+      ])
+    end
+  end
+
+  context 'when creating SRV record' do
+    let(:title) { "www.example.com-http-backend1" }
+    let(:params) {{ 
+      :target => "vm123.example.com.",
+      :label  => "_http._tcp.www",
+      :zone   => "example.com",
+      :priority => "10",
+      :weight   => "60",
+      :port     => "80",
+      :type   => "SRV",
+    }}
+  
+    it "should have valid record configuration" do
+      verify_concat_fragment_exact_contents(subject, 'dns-static-example.com+02content-www.example.com-http-backend1.dnsstatic', [
+        'update add _http._tcp.www.example.com. SRV 10 60 80 vm123.example.com.',
+      ])
+    end
+  end
+
+  context 'when creating CNAME with blank target' do
+    let(:title) { "badcname.example.com" }
+    let(:params) {{ 
+      :type   => "CNAME",
+    }}
+    
+    it { should_not compile }
+  end
+
+  context 'when creating SRV record with non-integer weight' do
+    let(:title) { "badsrv.example.com" }
+    let(:params) {{ 
+      :label  => "_http._tcp.badsrv",
+      :target => "vm123.example.com.",
+      :zone   => "example.com",
+      :priority => "10",
+      :weight   => "badweight",
+      :port     => "80",
+      :type   => "SRV",
+    }}
+    
+    it { should_not compile }
+  end
+
+end

--- a/spec/defines/dns_record_spec.rb
+++ b/spec/defines/dns_record_spec.rb
@@ -17,11 +17,11 @@ describe 'dns::record' do
 
   context 'when creating CNAME record' do
     let(:title) { "foo.example.com" }
-    let(:params) {{ 
+    let(:params) {{
       :target => "vm123.example.com.",
       :type   => "CNAME",
     }}
-  
+
     it "should have valid record configuration" do
       verify_concat_fragment_exact_contents(subject, 'dns-static-example.com+02content-foo.example.com.dnsstatic', [
         'update add foo.example.com. CNAME vm123.example.com.',
@@ -31,7 +31,7 @@ describe 'dns::record' do
 
   context 'when creating SRV record' do
     let(:title) { "www.example.com-http-backend1" }
-    let(:params) {{ 
+    let(:params) {{
       :target => "vm123.example.com.",
       :label  => "_http._tcp.www",
       :zone   => "example.com",
@@ -40,7 +40,7 @@ describe 'dns::record' do
       :port     => "80",
       :type   => "SRV",
     }}
-  
+
     it "should have valid record configuration" do
       verify_concat_fragment_exact_contents(subject, 'dns-static-example.com+02content-www.example.com-http-backend1.dnsstatic', [
         'update add _http._tcp.www.example.com. SRV 10 60 80 vm123.example.com.',
@@ -50,16 +50,16 @@ describe 'dns::record' do
 
   context 'when creating CNAME with blank target' do
     let(:title) { "badcname.example.com" }
-    let(:params) {{ 
+    let(:params) {{
       :type   => "CNAME",
     }}
-    
+
     it { should_not compile }
   end
 
   context 'when creating SRV record with non-integer weight' do
     let(:title) { "badsrv.example.com" }
-    let(:params) {{ 
+    let(:params) {{
       :label  => "_http._tcp.badsrv",
       :target => "vm123.example.com.",
       :zone   => "example.com",
@@ -68,7 +68,7 @@ describe 'dns::record' do
       :port     => "80",
       :type   => "SRV",
     }}
-    
+
     it { should_not compile }
   end
 

--- a/spec/defines/dns_zone_spec.rb
+++ b/spec/defines/dns_zone_spec.rb
@@ -64,7 +64,7 @@ describe 'dns::zone' do
         :notify   => 'Exec[update_dns_example.com]',
       })
     end
- 
+
   end
 
   context 'when reverse => true' do

--- a/spec/defines/dns_zone_spec.rb
+++ b/spec/defines/dns_zone_spec.rb
@@ -54,6 +54,19 @@ describe 'dns::zone' do
     ])
   end
 
+  context 'when including static records' do
+    let(:params) {{ :static_records => true }}
+    it "should create zone static file" do
+      should contain_file('/var/named/dynamic/db.example.com.nsupdate').with({
+        :owner    => 'named',
+        :group    => 'named',
+        :mode     => '0644',
+        :notify   => 'Exec[update_dns_example.com]',
+      })
+    end
+ 
+  end
+
   context 'when reverse => true' do
     let(:title) { '1.168.192.in-addr.arpa' }
     let(:params) {{ :reverse => true }}

--- a/templates/nsupdate_wrapper.erb
+++ b/templates/nsupdate_wrapper.erb
@@ -18,7 +18,7 @@ cp db.${C_ZONE}.nsupdate db.${C_ZONE}.copy
 if [ -f db.${C_ZONE}.nsupdate.old ]; then
 	diff db.${C_ZONE}.copy db.${C_ZONE}.nsupdate.old | egrep "^> update" | sed 's/^> //g' | sed -e 's/update add/update delete/g' >> db.${C_ZONE}.copy
 else
-  /etc/init.d/<%= scope.lookupvar('::dns::namedservicename') -%> reload
+  service <%= scope.lookupvar('::dns::namedservicename') -%> reload
 fi
 
 # Add the closing commands to the *.nsupdate.copy file 

--- a/templates/nsupdate_wrapper.erb
+++ b/templates/nsupdate_wrapper.erb
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -e
+
+PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+C_ZONE="$1"
+C_WORKDIR="<%= scope.lookupvar('::dns::zonefilepath') -%>"
+C_DNSKEY="rndc-key:$(cat <%= scope.lookupvar('::dns::rndckeypath') -%> | sed -n "3p" | awk -F'"' '{print $2}')"
+
+cd $C_WORKDIR
+
+# Create a copy of the nsupdate file. We will edit the copy later, and use it for making the changes
+cp db.${C_ZONE}.nsupdate db.${C_ZONE}.copy
+
+# If the zone has been edited before, an *.nsupdate.old file will exist. If it exists, we will diff it with
+# the new one to see whether there are records we no longer need. If it doesn't exist, we will assume the zone
+# is new, and reload BIND before making any changes in order to make sure BIND has the zone config loaded
+if [ -f db.${C_ZONE}.nsupdate.old ]; then
+	diff db.${C_ZONE}.copy db.${C_ZONE}.nsupdate.old | egrep "^> update" | sed 's/^> //g' | sed -e 's/update add/update delete/g' >> db.${C_ZONE}.copy
+else
+  /etc/init.d/<%= scope.lookupvar('::dns::namedservicename') -%> reload
+fi
+
+# Add the closing commands to the *.nsupdate.copy file 
+echo "show" >> db.${C_ZONE}.copy
+echo "send" >> db.${C_ZONE}.copy
+
+# Make the changes
+nsupdate -y ${C_DNSKEY} -v db.${C_ZONE}.copy
+
+
+if [ -f db.${C_ZONE}.nsupdate.old ]; then
+  mv db.${C_ZONE}.nsupdate db.${C_ZONE}.nsupdate.old
+else
+  cp db.${C_ZONE}.nsupdate db.${C_ZONE}.nsupdate.old
+fi
+
+rm db.${C_ZONE}.copy
+
+exit 0

--- a/templates/nsupdate_wrapper.erb
+++ b/templates/nsupdate_wrapper.erb
@@ -30,9 +30,9 @@ nsupdate -y ${C_DNSKEY} -v db.${C_ZONE}.copy
 
 
 if [ -f db.${C_ZONE}.nsupdate.old ]; then
-  mv db.${C_ZONE}.nsupdate db.${C_ZONE}.nsupdate.old
-else
   cp db.${C_ZONE}.nsupdate db.${C_ZONE}.nsupdate.old
+else
+  mv db.${C_ZONE}.nsupdate db.${C_ZONE}.nsupdate.old
 fi
 
 rm db.${C_ZONE}.copy

--- a/templates/static-header.erb
+++ b/templates/static-header.erb
@@ -1,0 +1,3 @@
+server localhost
+ttl <%= @ttl %>
+zone <%= @zone -%>.


### PR DESCRIPTION
As a result of the findings in #33 I have rebuilt my implementation to use nsupdate instead. This way, we manage static records the very same way Foreman manages the dynamic records of the zone, and we have no serial issues. I have chosen to use a wrapper script (nsupdate_wrapper) because it helps to handle deletion of unmanaged records (leftover exported resources after a node is decommissioned). 

In the future I want to try and re-solve this issue by creating an nsupdate provider, but for now this implementation works. 
