### PR TITLE
allow user to control allow-recursion on the global level

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,9 +12,13 @@ class dns(
   $localzonepath        = $::dns::params::localzonepath,
   $forwarders           = $::dns::params::forwarders,
   $listen_on_v6         = $::dns::params::listen_on_v6,
+  $allow_recursion      = $::dns::params::allow_recursion,
   $namedconf_template   = $::dns::params::namedconf_template,
   $optionsconf_template = $::dns::params::optionsconf_template,
 ) inherits dns::params {
+  validate_array($dns::forwarders)
+  validate_array($dns::allow_recursion)
+
   class { '::dns::install': } ~>
   class { '::dns::config': } ~>
   class { '::dns::service': } ->

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -56,4 +56,6 @@ class dns::params {
     $forwarders           = []
 
     $listen_on_v6         = 'any'
+
+    $allow_recursion      = []
 }

--- a/templates/options.conf.erb
+++ b/templates/options.conf.erb
@@ -4,6 +4,11 @@ forwarders { <%= scope.lookupvar('::dns::forwarders').join("; ") %>; };
 <% end -%>
 
 listen-on-v6 { <%= scope.lookupvar('::dns::listen_on_v6') %>; };
+
+<% unless scope.lookupvar('::dns::allow_recursion').empty? -%>
+allow-recursion { <%= scope.lookupvar('::dns::allow_recursion').join("; ") %>; };
+<% end -%>
+
 <% if (@osfamily =~ /^(FreeBSD|DragonFly)$/) -%>
 pid-file "/var/run/named/pid";
 <% end -%>


### PR DESCRIPTION
Allows a user to enable recursion on bind in the global level. useful for situation where multiple networks require access to a single server used as a full DNS server (not just for local zones).