### PR TITLE
Add options and zone possibilities

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,12 +12,20 @@ class dns(
   $localzonepath        = $::dns::params::localzonepath,
   $forwarders           = $::dns::params::forwarders,
   $listen_on_v6         = $::dns::params::listen_on_v6,
+  $recursion            = $::dns::params::recursion,
   $allow_recursion      = $::dns::params::allow_recursion,
+  $allow_query          = $::dns::params::allow_query,
+  $dnssec_enable        = $::dns::params::dnssec_enable,
+  $dnssec_validation    = $::dns::params::dnssec_validation,
   $namedconf_template   = $::dns::params::namedconf_template,
   $optionsconf_template = $::dns::params::optionsconf_template,
 ) inherits dns::params {
   validate_array($dns::forwarders)
   validate_array($dns::allow_recursion)
+  validate_array($dns::allow_query)
+  validate_re($dns::recursion, '^(yes|no)$', 'Only \'yes\' and \'no\' are valid values for recursion field')
+  validate_re($dns::dnssec_enable, '^(yes|no)$', 'Only \'yes\' and \'no\' are valid values for dnssec_enable field')
+  validate_re($dns::dnssec_validation, '^(yes|no|auto)$', 'Only \'yes\', \'no\' and \'auto\' are valid values for dnssec_validation field')
 
   class { '::dns::install': } ~>
   class { '::dns::config': } ~>

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -57,5 +57,10 @@ class dns::params {
 
     $listen_on_v6         = 'any'
 
+    $recursion            = 'yes'
     $allow_recursion      = []
+    $allow_query          = [ 'any' ]
+
+    $dnssec_enable        = 'yes'
+    $dnssec_validation    = 'yes'
 }

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -16,10 +16,14 @@ define dns::zone (
     $contact        = "root.${title}.",
     $zonefilepath   = $::dns::zonefilepath,
     $filename       = "db.${title}",
+    $manage_file    = true,
+    $forward        = 'first',
+    $forwarders     = [],
 ) {
 
-  validate_bool($reverse)
-  validate_array($masters, $allow_transfer)
+  validate_bool($reverse, $manage_file)
+  validate_array($masters, $allow_transfer, $forwarders)
+  validate_re($forward, '^(first|only)$', 'Only \'first\' or \'only\' are valid values for forward field')
 
   $zonefilename = "${zonefilepath}/${filename}"
 
@@ -29,13 +33,15 @@ define dns::zone (
     order   => "10-${zone}",
   }
 
-  file { $zonefilename:
-    ensure  => file,
-    owner   => $dns::user,
-    group   => $dns::group,
-    mode    => '0644',
-    content => template('dns/zone.header.erb'),
-    replace => false,
-    notify  => Service[$::dns::namedservicename],
+  if $manage_file {
+    file { $zonefilename:
+      ensure  => file,
+      owner   => $dns::user,
+      group   => $dns::group,
+      mode    => '0644',
+      content => template('dns/zone.header.erb'),
+      replace => false,
+      notify  => Service[$::dns::namedservicename],
+    }
   }
 }

--- a/templates/named.zone.erb
+++ b/templates/named.zone.erb
@@ -1,6 +1,11 @@
 zone "<%= @zone %>" {
     type <%= @zonetype %>;
+<% if @zonetype == 'forward' -%>
+    forward <%= @forward %>;
+<% end -%>
+<% if @manage_file == true -%>
     file "<%= @zonefilename %>";
+<% end -%>
 <% if @zonetype == 'master' -%>
     update-policy {
             grant rndc-key zonesub ANY;
@@ -11,5 +16,8 @@ zone "<%= @zone %>" {
 <% end -%>
 <% unless @masters.empty? -%>
     masters { <%= @masters.join('; ') %>; };
+<% end -%>
+<% unless @forwarders.empty? -%>
+    forwarders { <%= @forwarders.join('; ') %>; };
 <% end -%>
 };

--- a/templates/options.conf.erb
+++ b/templates/options.conf.erb
@@ -3,6 +3,11 @@ directory "<%= scope.lookupvar('::dns::vardir') %>";
 forwarders { <%= scope.lookupvar('::dns::forwarders').join("; ") %>; };
 <% end -%>
 
+recursion <%= scope.lookupvar('::dns::recursion') %>;
+allow-query { <%= scope.lookupvar('::dns::allow_query').join("; ") %>; };
+dnssec-enable <%= scope.lookupvar('::dns::dnssec_enable') %>;
+dnssec-validation <%= scope.lookupvar('::dns::dnssec_validation') %>;
+
 listen-on-v6 { <%= scope.lookupvar('::dns::listen_on_v6') %>; };
 
 <% unless scope.lookupvar('::dns::allow_recursion').empty? -%>


### PR DESCRIPTION
I added diverse options for bind that can be necessary to manage your own DNS :
- recursion
- allow_query
- dnssec_enable
- dnssec_validation

And also the possibility to not create a zone file when you declare a zone (only add an entry in the conf file)

An finally, I adapted the templates.