### PR TITLE
use ensure_packages

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,7 +1,4 @@
 # Install dns service
 class dns::install {
-  package { 'dns':
-    ensure => present,
-    name   => $dns::dns_server_package,
-  }
+  ensure_packages([$dns::dns_server_package])
 }

--- a/spec/classes/dns_init_spec.rb
+++ b/spec/classes/dns_init_spec.rb
@@ -18,7 +18,7 @@ describe 'dns' do
       it { should contain_class('dns::config') }
       it { should contain_class('dns::service') }
 
-      it { should contain_package('dns').with_ensure('present').with_name('bind') }
+      it { should contain_package('bind').with_ensure('present') }
 
       it { should contain_file('/etc/named/options.conf').
                   with_content(%r{listen-on-v6 { any; };}) }
@@ -57,7 +57,7 @@ describe 'dns' do
       it { should contain_class('dns::config') }
       it { should contain_class('dns::service') }
 
-      it { should contain_package('dns').with_ensure('present').with_name('bind910') }
+      it { should contain_package('bind910').with_ensure('present') }
 
       it { should contain_file('/usr/local/etc/namedb/options.conf').
                   with_content(%r{listen-on-v6 { any; };}) }


### PR DESCRIPTION
I'm wondering if the test shouldn't be something like `should contain_ensure_packages(['bind'])`, but that doesn't work.