### PR TITLE
Add the ability to set empty-zones-enable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,6 +15,7 @@ class dns(
   $recursion            = $::dns::params::recursion,
   $allow_recursion      = $::dns::params::allow_recursion,
   $allow_query          = $::dns::params::allow_query,
+  $empty_zones_enable   = $::dns::params::empty_zones_enable,
   $dnssec_enable        = $::dns::params::dnssec_enable,
   $dnssec_validation    = $::dns::params::dnssec_validation,
   $namedconf_template   = $::dns::params::namedconf_template,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -41,7 +41,7 @@ class dns::params {
         fail ("Unsupported operating system family ${::osfamily}")
       }
     }
-    
+
     $namedconf_template   = 'dns/named.conf.erb'
     $optionsconf_template = 'dns/options.conf.erb'
 
@@ -60,6 +60,8 @@ class dns::params {
     $recursion            = 'yes'
     $allow_recursion      = []
     $allow_query          = [ 'any' ]
+
+    $empty_zones_enable   = 'yes'
 
     $dnssec_enable        = 'yes'
     $dnssec_validation    = 'yes'

--- a/spec/classes/dns_init_spec.rb
+++ b/spec/classes/dns_init_spec.rb
@@ -21,7 +21,8 @@ describe 'dns' do
       it { should contain_package('bind').with_ensure('present') }
 
       it { should contain_file('/etc/named/options.conf').
-                  with_content(%r{listen-on-v6 { any; };}) }
+                  with_content(%r{listen-on-v6 { any; };}).
+                  with_content(%r{empty-zones-enable yes;}) }
       it { should contain_file('/var/named/dynamic').with_ensure('directory') }
       it { should contain_file('/etc/named.conf').
                   with_content(%r{include "/etc/rndc.key"}).
@@ -38,6 +39,11 @@ describe 'dns' do
       let(:params) { {:listen_on_v6 => 'none'} }
       it { should contain_file('/etc/named/options.conf').
                   with_content(%r{listen-on-v6 { none; };}) }
+    end
+    describe 'with empty zones disabled' do
+      let(:params) { {:empty_zones_enable => 'no'} }
+      it { should contain_file('/etc/named/options.conf').
+                  with_content(%r{empty-zones-enable no;}) }
     end
   end
 

--- a/templates/options.conf.erb
+++ b/templates/options.conf.erb
@@ -8,6 +8,8 @@ allow-query { <%= scope.lookupvar('::dns::allow_query').join("; ") %>; };
 dnssec-enable <%= scope.lookupvar('::dns::dnssec_enable') %>;
 dnssec-validation <%= scope.lookupvar('::dns::dnssec_validation') %>;
 
+empty-zones-enable <%= scope.lookupvar('::dns::empty_zones_enable') %>;
+
 listen-on-v6 { <%= scope.lookupvar('::dns::listen_on_v6') %>; };
 
 <% unless scope.lookupvar('::dns::allow_recursion').empty? -%>


### PR DESCRIPTION
That option allows you to forward requests of PTR records of RFC1918
IP addresses.