### PR TITLE
Do not set DNS as an insecure open recurive server by default

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -57,7 +57,7 @@ class dns::params {
 
     $listen_on_v6         = 'any'
 
-    $recursion            = 'yes'
+    $recursion            = 'no'
     $allow_recursion      = []
     $allow_query          = [ 'any' ]
 


### PR DESCRIPTION
The default settings create an open DNS server which allows a very significant attack vector for DNS spoofing attacks.