### PR TITLE
Add the forward [ only | first ] option at the global level

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,6 +10,7 @@ class dns(
   $namedservicename     = $::dns::params::namedservicename,
   $zonefilepath         = $::dns::params::zonefilepath,
   $localzonepath        = $::dns::params::localzonepath,
+  $forward              = $::dns::params::forward,
   $forwarders           = $::dns::params::forwarders,
   $listen_on_v6         = $::dns::params::listen_on_v6,
   $recursion            = $::dns::params::recursion,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,6 +31,9 @@ class dns(
   validate_re($dns::dnssec_enable, '^(yes|no)$', 'Only \'yes\' and \'no\' are valid values for dnssec_enable field')
   validate_re($dns::dnssec_validation, '^(yes|no|auto)$', 'Only \'yes\', \'no\' and \'auto\' are valid values for dnssec_validation field')
   validate_re($dns::service_ensure, '^running|true|stopped|false$', 'Only \'running\', \'false\', \'stopped\' and \'false\' are validate values for service_ensure field')
+  if $dns::forward {
+    validate_re($dns::forward, '^(only|first)$', 'Only \'only\' and \'first\' are valid values for forward field')
+  }
   validate_bool($dns::service_enable)
 
   class { '::dns::install': } ~>

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -53,6 +53,7 @@ class dns::params {
     #pertaining to views
     $publicviewpath       = "${dnsdir}/zones.conf"
 
+    $forward              = undef
     $forwarders           = []
 
     $listen_on_v6         = 'any'

--- a/spec/classes/dns_init_spec.rb
+++ b/spec/classes/dns_init_spec.rb
@@ -62,12 +62,12 @@ describe 'dns' do
       it { should contain_file('/etc/named/options.conf').with_content(%r{forward only;}) }
     end
 
-    describe 'with forward first' do
-      let(:params) { {:forward => 'first'} }
-      it { should contain_file('/etc/named/options.conf').with_content(%r{forward first;}) }
+    describe 'with undef forward' do
+      let(:params) { {:forward => :undef} }
+      it { should contain_file('/etc/named/options.conf').without_content(%r{forward ;}) }
     end
 
-      describe 'with service_ensure stopped' do
+    describe 'with service_ensure stopped' do
       let(:params) { {:service_ensure => 'stopped'} }
       it { should contain_service('named').with_ensure('stopped').with_enable(true) }
     end

--- a/spec/classes/dns_init_spec.rb
+++ b/spec/classes/dns_init_spec.rb
@@ -46,7 +46,17 @@ describe 'dns' do
                   with_content(%r{empty-zones-enable no;}) }
     end
 
-    describe 'with service_ensure stopped' do
+    describe 'with forward only' do
+      let(:params) { {:forward => 'only'} }
+      it { should contain_file('/etc/named/options.conf').with_content(%r{forward only;}) }
+    end
+
+    describe 'with forward first' do
+      let(:params) { {:forward => 'first'} }
+      it { should contain_file('/etc/named/options.conf').with_content(%r{forward first;}) }
+    end
+
+      describe 'with service_ensure stopped' do
       let(:params) { {:service_ensure => 'stopped'} }
       it { should contain_service('named').with_ensure('stopped').with_enable(true) }
     end

--- a/templates/options.conf.erb
+++ b/templates/options.conf.erb
@@ -2,6 +2,9 @@ directory "<%= scope.lookupvar('::dns::vardir') %>";
 <% unless scope.lookupvar('::dns::forwarders').empty? -%>
 forwarders { <%= scope.lookupvar('::dns::forwarders').join("; ") %>; };
 <% end -%>
+<% unless [nil, :undefined, :undef, ''].include?(scope.lookupvar('::dns::forward')) -%>
+forward <%= scope.lookupvar('::dns::forward') %>;
+<% end -%>
 
 recursion <%= scope.lookupvar('::dns::recursion') %>;
 allow-query { <%= scope.lookupvar('::dns::allow_query').join("; ") %>; };


### PR DESCRIPTION
There is already the ability to configure forwarders, but the forward option is missing - therefore adding it.