### PR TITLE
Limit recursion to localnets and localhost

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -58,7 +58,7 @@ class dns::params {
     $listen_on_v6         = 'any'
 
     $recursion            = 'yes'
-    $allow_recursion      = []
+    $allow_recursion      = [ 'localnets', 'localhost' ]
     $allow_query          = [ 'any' ]
 
     $empty_zones_enable   = 'yes'

--- a/spec/classes/dns_init_spec.rb
+++ b/spec/classes/dns_init_spec.rb
@@ -31,6 +31,17 @@ describe 'dns' do
                   with_content(%r{include "/etc/named/options.conf"}) }
       it { should contain_exec('create-rndc.key').
                   with_command("/usr/sbin/rndc-confgen -r /dev/urandom -a -c /etc/rndc.key") }
+      it { verify_exact_contents(catalogue, '/etc/named/options.conf', [
+          'directory "/var/named";',
+          'recursion yes;',
+          'allow-query { any; };',
+          'dnssec-enable yes;',
+          'dnssec-validation yes;',
+          'empty-zones-enable yes;',
+          'listen-on-v6 { any; };',
+          'allow-recursion { localnets; localhost; };'
+        ])
+      }
 
       it { should contain_service('named').with_ensure('running').with_enable(true) }
     end


### PR DESCRIPTION
This doesn't turn the server into an open recursor by default and
matches the defaults introduced in BIND 9.4.1-P1.

https://kb.isc.org/article/AA-00269/0/What-has-changed-in-the-behavior-of-allow-recursion-and-allow-query-cache.html

Reported in https://github.com/theforeman/puppet-dns/pull/49 by @kmcfate