### PR TITLE
Add dns_notify to dns class and dns::zone define

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,6 +17,7 @@ class dns(
   $allow_recursion      = $::dns::params::allow_recursion,
   $allow_query          = $::dns::params::allow_query,
   $empty_zones_enable   = $::dns::params::empty_zones_enable,
+  $dns_notify           = $::dns::params::dns_notify,
   $dnssec_enable        = $::dns::params::dnssec_enable,
   $dnssec_validation    = $::dns::params::dnssec_validation,
   $namedconf_template   = $::dns::params::namedconf_template,
@@ -33,6 +34,9 @@ class dns(
   validate_re($dns::service_ensure, '^running|true|stopped|false$', 'Only \'running\', \'false\', \'stopped\' and \'false\' are validate values for service_ensure field')
   if $dns::forward {
     validate_re($dns::forward, '^(only|first)$', 'Only \'only\' and \'first\' are valid values for forward field')
+  }
+  if $dns::dns_notify {
+    validate_re($dns_notify, '^(yes|no|explicit)$', 'Only \'yes\', \'no\', or \'explicit\' are valid values for dns_notify field')
   }
   validate_bool($dns::service_enable)
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -64,6 +64,8 @@ class dns::params {
 
     $empty_zones_enable   = 'yes'
 
+    $dns_notify           = undef
+
     $dnssec_enable        = 'yes'
     $dnssec_validation    = 'yes'
 

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -20,13 +20,23 @@ define dns::zone (
     $manage_file    = true,
     $forward        = 'first',
     $forwarders     = [],
+    $dns_notify     = undef,
 ) {
 
   validate_bool($reverse, $manage_file)
   validate_array($masters, $allow_transfer, $forwarders, $also_notify)
   validate_re($forward, '^(first|only)$', 'Only \'first\' or \'only\' are valid values for forward field')
+  if $dns_notify {
+    validate_re($dns_notify, '^(yes|no|explicit)$', 'Only \'yes\', \'no\', or \'explicit\' are valid values for dns_notify field')
+  }
 
   $zonefilename = "${zonefilepath}/${filename}"
+
+  if $zonetype == 'slave' {
+    $_dns_notify = pick($dns_notify, 'no')
+  } else {
+    $_dns_notify = $dns_notify
+  }
 
   concat::fragment { "dns_zones+10_${zone}.dns":
     target  => $::dns::publicviewpath,

--- a/spec/classes/dns_init_spec.rb
+++ b/spec/classes/dns_init_spec.rb
@@ -57,6 +57,12 @@ describe 'dns' do
                   with_content(%r{empty-zones-enable no;}) }
     end
 
+    describe 'with dns_notify disabled' do
+      let(:params) { {:dns_notify => 'no' } }
+      it { should contain_file('/etc/named/options.conf').
+                  with_content(%r{notify no;}) }
+    end
+
     describe 'with forward only' do
       let(:params) { {:forward => 'only'} }
       it { should contain_file('/etc/named/options.conf').with_content(%r{forward only;}) }

--- a/spec/defines/dns_zone_spec.rb
+++ b/spec/defines/dns_zone_spec.rb
@@ -151,6 +151,7 @@ describe 'dns::zone' do
         '    type slave;',
         '    file "/var/named/dynamic/db.example.com";',
         '    masters { 192.168.1.1; };',
+        '    notify no;',
         '};',
       ])
     end
@@ -164,6 +165,24 @@ describe 'dns::zone' do
           '    type slave;',
           '    file "/var/named/dynamic/db.example.com";',
           '    masters { 192.168.1.1; 192.168.1.2; };',
+          '    notify no;',
+          '};',
+        ])
+      end
+    end
+
+    context 'when dns_notify => no' do
+      let(:params) {{ :dns_notify => 'no' }}
+
+      it "should have valid slave zone configuration" do
+        verify_concat_fragment_exact_contents(catalogue, 'dns_zones+10_example.com.dns', [
+          'zone "example.com" {',
+          '    type master;',
+          '    file "/var/named/dynamic/db.example.com";',
+          '    update-policy {',
+          '            grant rndc-key zonesub ANY;',
+          '    };',
+          '    notify no;',
           '};',
         ])
       end

--- a/templates/named.zone.erb
+++ b/templates/named.zone.erb
@@ -23,4 +23,7 @@ zone "<%= @zone %>" {
 <% unless @forwarders.empty? -%>
     forwarders { <%= @forwarders.join('; ') %>; };
 <% end -%>
+<% if @_dns_notify -%>
+    notify <%= @_dns_notify %>;
+<% end -%>
 };

--- a/templates/options.conf.erb
+++ b/templates/options.conf.erb
@@ -13,6 +13,9 @@ dnssec-validation <%= scope.lookupvar('::dns::dnssec_validation') %>;
 
 empty-zones-enable <%= scope.lookupvar('::dns::empty_zones_enable') %>;
 
+<% unless [nil, :undefined, :undef, ''].include?(scope.lookupvar('::dns::dns_notify')) -%>
+notify <%= scope.lookupvar('::dns::dns_notify') %>;
+<% end -%>
 listen-on-v6 { <%= scope.lookupvar('::dns::listen_on_v6') %>; };
 
 <% unless scope.lookupvar('::dns::allow_recursion').empty? -%>


### PR DESCRIPTION
In a situation with a single master and multiple slaves, the slaves will end up attempting to notify other slaves of updates to the zones.  Messages like this will appear

```
Jan 20 10:53:33 HOSTNAME named[1628]: client SLAVE_IP#52691: received notify for zone 'DOMAIN'
Jan 20 10:53:33 HOSTNAME named[1628]: zone DOMAIN/IN: refused notify from non-master: SLAVE_IP#52691
```

It may be worth making the value for `notify` automatically `no` when `zonetype` is `slave`, but wasn't sure if such an assumption would be too much.