### PR TITLE
Change default path for zones.conf to /etc/named/zones.conf for RedHat

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,6 +7,7 @@ class dns::params {
         $optionspath        = "${dnsdir}/named.conf.options"
         $zonefilepath       = "${vardir}/zones"
         $localzonepath      = "${dnsdir}/zones.rfc1918"
+        $publicviewpath     = "${dnsdir}/zones.conf"
         $dns_server_package = 'bind9'
         $namedservicename   = 'bind9'
         $user               = 'bind'
@@ -19,6 +20,7 @@ class dns::params {
         $optionspath        = '/etc/named/options.conf'
         $zonefilepath       = "${vardir}/dynamic"
         $localzonepath      = "${dnsdir}/named.rfc1912.zones"
+        $publicviewpath     = "${dnsdir}/named/zones.conf"
         $dns_server_package = 'bind'
         $namedservicename   = 'named'
         $user               = 'named'
@@ -31,6 +33,7 @@ class dns::params {
         $optionspath        = '/usr/local/etc/namedb/options.conf'
         $zonefilepath       = "${dnsdir}/dynamic"
         $localzonepath      = undef # "${dnsdir}/master/empty.db"
+        $publicviewpath     = "${dnsdir}/zones.conf"
         $dns_server_package = 'bind910'
         $namedservicename   = 'named'
         $user               = 'bind'
@@ -49,9 +52,6 @@ class dns::params {
 
     #pertaining to rndc
     $rndckeypath          = "${dnsdir}/rndc.key"
-
-    #pertaining to views
-    $publicviewpath       = "${dnsdir}/zones.conf"
 
     $forward              = undef
     $forwarders           = []

--- a/spec/classes/dns_init_spec.rb
+++ b/spec/classes/dns_init_spec.rb
@@ -48,7 +48,7 @@ describe 'dns' do
           '};',
           'include "/etc/named.rfc1912.zones";',
           '// Public view read by Server Admin',
-          'include "/etc/zones.conf";',
+          'include "/etc/named/zones.conf";',
         ])
       }
 
@@ -109,7 +109,7 @@ describe 'dns' do
           '        127.0.1.0/24;',
           '};',
           '// Public view read by Server Admin',
-          'include "/etc/zones.conf";',
+          'include "/etc/named/zones.conf";',
         ])
       }
     end


### PR DESCRIPTION
Set default path for zones.conf to /etc/named/zones.conf to allow easier use of named with chroot enabled

I don't like the fact that existing systems will have /etc/zones.conf left behind unless a site was passing the `publicviewpath` parameter.  Wasn't sure how to best handle changing default path.