### PR TITLE
ensure_packages still results in dup definition

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,4 +1,6 @@
 # Install dns service
 class dns::install {
-  ensure_packages([$dns::dns_server_package])
+  if ! empty($dns::dns_server_package) {
+    ensure_packages([$dns::dns_server_package])
+  }
 }


### PR DESCRIPTION
I have a class that wants to use the puppet-dns class. In *my* class, I have:
`ensure_packages(['bind', 'bind-utils'], {ensure => 'installed'})`
There is also an 'ensure_packages' test inside install.pp; the two ensure_packages calls should have worked together to avoid duplicate package definition errors.
However, I received:
`Error: Duplicate declaration: Package[bind] is already declared; cannot redeclare at /root/proj/puppet/modules/dns/manifests/install.pp:3`
I first tried to set the variable name to empty:
`    class {
      '::dns':
        dns_server_package => '';
    }
`
However, that simply caused a puppet syntax error. So I made the change to test for an empty package name and avoid ensure_packages altogether in this fork.