### PR TITLE
Use concat fragments instead of file resource templates for config

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,28 +7,36 @@ class dns::config {
     group => $dns::params::group,
     mode  => '0640',
   }
+
   concat::fragment { 'dns_zones+01-header.dns':
     target  => $::dns::publicviewpath,
     content => ' ',
     order   => '01',
   }
 
-  file {
-    $dns::namedconf_path:
-      owner   => root,
-      group   => $dns::params::group,
-      mode    => '0640',
-      content => template($::dns::namedconf_template);
-    $dns::optionspath:
-      owner   => root,
-      group   => $dns::params::group,
-      mode    => '0640',
-      content => template($::dns::optionsconf_template);
-    $dns::zonefilepath:
-      ensure  => directory,
-      owner   => $dns::params::user,
-      group   => $dns::params::group,
-      mode    => '0640';
+  concat { [$::dns::namedconf_path, $::dns::optionspath]:
+    owner => root,
+    group => $::dns::params::group,
+    mode  => '0640',
+  }
+
+  concat::fragment { 'named.conf+10-main.dns':
+    target  => $::dns::namedconf_path,
+    content => template($::dns::namedconf_template),
+    order   => '10',
+  }
+
+  concat::fragment { 'options.conf+10-main.dns':
+    target  => $::dns::optionspath,
+    content => template($::dns::optionsconf_template),
+    order   => '10',
+  }
+
+  file { $dns::zonefilepath:
+    ensure => directory,
+    owner  => $dns::params::user,
+    group  => $dns::params::group,
+    mode   => '0640',
   }
 
   exec { 'create-rndc.key':
@@ -41,4 +49,3 @@ class dns::config {
     mode  => '0640',
   }
 }
-


### PR DESCRIPTION
The net effect of this change is zero - it's backwards compatible
and does not result in any change for users.
The concat resources create the files with the same permissions
and the concat fragments take care of inserting the templates with
the same feature to override the template if need be.

However, since concat is now used, consumers of puppet-dns can now
insert their own concat fragments without having to maintain their
own template.
Before this change, if we wanted to diverge slightly from the
template, we would need to "fork" the template and maintain our own.
We could otherwise edit the file with resources like file_line but
this is not idempotent.

Spec test coverage for these bits have been improved a bit and
standardized as part of the commit.