### PR TITLE
allow additional_options

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,6 +48,7 @@ class dns (
   $controls             = $::dns::params::controls,
   $service_ensure       = $::dns::params::service_ensure,
   $service_enable       = $::dns::params::service_enable,
+  $additional_options   = $::dns::params::additional_options,
 ) inherits dns::params {
   validate_array($dns::forwarders)
   validate_array($dns::allow_recursion)
@@ -65,6 +66,7 @@ class dns (
   validate_bool($dns::service_enable)
   validate_hash($controls)
   validate_hash($acls)
+  validate_hash($additional_options)
 
   class { '::dns::install': } ~>
   class { '::dns::config': } ~>

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -74,4 +74,7 @@ class dns::params {
     $service_ensure       = 'running'
     $service_enable       = true
     $acls                 = {}
+
+    $additional_options   = {}
+
 }

--- a/spec/classes/dns_init_spec.rb
+++ b/spec/classes/dns_init_spec.rb
@@ -121,6 +121,11 @@ describe 'dns' do
           'include "/etc/named/zones.conf";'
       ])}
     end
+
+    describe 'with additional options' do
+      let(:params) { { :additional_options => { 'max-cache-ttl' => 3600, 'max-ncache-ttl' => 3600 } } }
+      it { should contain_concat_fragment('options.conf+10-main.dns').with_content('/max-cache-ttl 3600;\nmax-ncache-ttl 3600;/') }
+    end
   end
 
   describe 'on FreeBSD with no custom parameters' do

--- a/spec/classes/dns_init_spec.rb
+++ b/spec/classes/dns_init_spec.rb
@@ -124,7 +124,18 @@ describe 'dns' do
 
     describe 'with additional options' do
       let(:params) { { :additional_options => { 'max-cache-ttl' => 3600, 'max-ncache-ttl' => 3600 } } }
-      it { should contain_concat_fragment('options.conf+10-main.dns').with_content('/max-cache-ttl 3600;\nmax-ncache-ttl 3600;/') }
+      it { verify_concat_fragment_contents(catalogue, 'options.conf+10-main.dns', [
+          'directory "/var/named";',
+          'recursion yes;',
+          'allow-query { any; };',
+          'dnssec-enable yes;',
+          'dnssec-validation yes;',
+          'empty-zones-enable yes;',
+          'listen-on-v6 { any; };',
+          'allow-recursion { localnets; localhost; };',
+          'max-cache-ttl 3600;',
+          'max-ncache-ttl 3600;'
+      ])}
     end
   end
 

--- a/templates/options.conf.erb
+++ b/templates/options.conf.erb
@@ -25,3 +25,7 @@ allow-recursion { <%= scope.lookupvar('::dns::allow_recursion').join("; ") %>; }
 <% if (@osfamily =~ /^(FreeBSD|DragonFly)$/) -%>
 pid-file "/var/run/named/pid";
 <% end -%>
+
+<%- scope.lookupvar('::dns::additional_options').sort_by {|k, v| k}.each do |option, value| -%>
+<%= option %> <%= value %>;
+<%- end -%>


### PR DESCRIPTION
- adds a hash parameter to allow additional global options to be added to options.conf