### PR TITLE
Do not configure listen-on-v6 parameter if it's not set

### DIFF
--- a/spec/classes/dns_init_spec.rb
+++ b/spec/classes/dns_init_spec.rb
@@ -91,6 +91,12 @@ describe 'dns' do
       it { should contain_concat_fragment('options.conf+10-main.dns').without_content('/forward ;/') }
     end
 
+    describe 'with false listen_on_v6' do
+      let(:params) { {:listen_on_v6 => false} }
+      it { should contain_concat('/etc/named/options.conf') }
+      it { should contain_concat_fragment('options.conf+10-main.dns').without_content('/listen_on_v6/') }
+    end
+
     describe 'with service_ensure stopped' do
       let(:params) { {:service_ensure => 'stopped'} }
       it { should contain_service('named').with_ensure('stopped').with_enable(true) }

--- a/templates/options.conf.erb
+++ b/templates/options.conf.erb
@@ -16,7 +16,9 @@ empty-zones-enable <%= scope.lookupvar('::dns::empty_zones_enable') %>;
 <% unless [nil, :undefined, :undef, ''].include?(scope.lookupvar('::dns::dns_notify')) -%>
 notify <%= scope.lookupvar('::dns::dns_notify') %>;
 <% end -%>
+<% unless [false, nil, :undefined, :undef, ''].include?(scope.lookupvar('::dns::listen_on_v6')) -%>
 listen-on-v6 { <%= scope.lookupvar('::dns::listen_on_v6') %>; };
+<% end -%>
 
 <% unless scope.lookupvar('::dns::allow_recursion').empty? -%>
 allow-recursion { <%= scope.lookupvar('::dns::allow_recursion').join("; ") %>; };


### PR DESCRIPTION
The listen-on-v6 parameter would always be configured in
options.conf. This makes it unflexible with the use case of making
BIND listen on another port than 53.
Make it so the configuration is added only when the parameter is set
so that, if required, a user can set listen_on_v6 to false and add
his own configuration in additional_options.

Closes: #67