### PR TITLE
Add some variables

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,7 +35,7 @@ class dns (
   $forward              = $::dns::params::forward,
   $forwarders           = $::dns::params::forwarders,
   $listen_on_v6         = $::dns::params::listen_on_v6,
-  $listen_on_v4         = $::dns::params::listen_on_v4,
+  $listen_on            = $::dns::params::listen_on,
   $recursion            = $::dns::params::recursion,
   $allow_recursion      = $::dns::params::allow_recursion,
   $allow_query          = $::dns::params::allow_query,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,6 +35,7 @@ class dns (
   $forward              = $::dns::params::forward,
   $forwarders           = $::dns::params::forwarders,
   $listen_on_v6         = $::dns::params::listen_on_v6,
+  $listen_on_53         = $::dns::params::listen_on_53,
   $recursion            = $::dns::params::recursion,
   $allow_recursion      = $::dns::params::allow_recursion,
   $allow_query          = $::dns::params::allow_query,
@@ -49,6 +50,11 @@ class dns (
   $service_ensure       = $::dns::params::service_ensure,
   $service_enable       = $::dns::params::service_enable,
   $additional_options   = $::dns::params::additional_options,
+  $transfert_source     = $::dns::params::transfert_source,
+  $transfert_source_port= $::dns::params::transfert_source_port,
+  $notify_source        = $::dns::params::notify_source,
+  $notify_source_port   = $::dns::params::notify_source_port
+
 ) inherits dns::params {
   validate_array($dns::forwarders)
   validate_array($dns::allow_recursion)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,10 +50,10 @@ class dns (
   $service_ensure       = $::dns::params::service_ensure,
   $service_enable       = $::dns::params::service_enable,
   $additional_options   = $::dns::params::additional_options,
-  $transfert_source     = $::dns::params::transfert_source,
-  $transfert_source_port= $::dns::params::transfert_source_port,
+  $transfer_source      = $::dns::params::transfer_source,
+  $transfer_source_port = $::dns::params::transfer_source_port,
   $notify_source        = $::dns::params::notify_source,
-  $notify_source_port   = $::dns::params::notify_source_port
+  $notify_source_port   = $::dns::params::notify_source_port,
 
 ) inherits dns::params {
   validate_array($dns::forwarders)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,7 +35,7 @@ class dns (
   $forward              = $::dns::params::forward,
   $forwarders           = $::dns::params::forwarders,
   $listen_on_v6         = $::dns::params::listen_on_v6,
-  $listen_on_53         = $::dns::params::listen_on_53,
+  $listen_on_v4         = $::dns::params::listen_on_v4,
   $recursion            = $::dns::params::recursion,
   $allow_recursion      = $::dns::params::allow_recursion,
   $allow_query          = $::dns::params::allow_query,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -70,6 +70,7 @@ class dns::params {
     $forwarders           = []
 
     $listen_on_v6         = 'any'
+    $listen_on_53         = 'any'
 
     $recursion            = 'yes'
     $allow_recursion      = [ 'localnets', 'localhost' ]
@@ -87,6 +88,12 @@ class dns::params {
     $service_ensure       = 'running'
     $service_enable       = true
     $acls                 = {}
+
+    $transfer_source      = undef
+    $transfer_source_port = undef
+
+    $notify_source        = undef
+    $notify_source_port   = undef
 
     $additional_options   = {}
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -70,7 +70,7 @@ class dns::params {
     $forwarders           = []
 
     $listen_on_v6         = 'any'
-    $listen_on_53         = 'any'
+    $listen_on_v4         = 'any'
 
     $recursion            = 'yes'
     $allow_recursion      = [ 'localnets', 'localhost' ]

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -70,7 +70,7 @@ class dns::params {
     $forwarders           = []
 
     $listen_on_v6         = 'any'
-    $listen_on_v4         = 'any'
+    $listen_on            = 'any'
 
     $recursion            = 'yes'
     $allow_recursion      = [ 'localnets', 'localhost' ]

--- a/templates/named.zone.erb
+++ b/templates/named.zone.erb
@@ -6,9 +6,7 @@ zone "<%= @zone %>" {
     forwarders { <%= @forwarders.join('; ') %>; };
 <% end -%>
 <% end -%>
-<% if @manage_file == true -%>
     file "<%= @zonefilename %>";
-<% end -%>
 <% if @zonetype == 'master' -%>
     update-policy {
             grant rndc-key zonesub ANY;

--- a/templates/options.conf.erb
+++ b/templates/options.conf.erb
@@ -19,8 +19,8 @@ notify <%= scope.lookupvar('::dns::dns_notify') %>;
 <% unless [false, nil, :undefined, :undef, ''].include?(scope.lookupvar('::dns::listen_on_v6')) -%>
 listen-on-v6 { <%= scope.lookupvar('::dns::listen_on_v6') %>; };
 <% end -%>
-<% unless [false, nil, :undefined, :undef, ''].include?(scope.lookupvar('::dns::listen_on_v4')) -%>
-listen-on port 53 { <%= scope.lookupvar('::dns::listen_on_v4') %>; };
+<% unless [false, nil, :undefined, :undef, ''].include?(scope.lookupvar('::dns::listen_on')) -%>
+listen-on port 53 { <%= scope.lookupvar('::dns::listen_on') %>; };
 <% end -%>
 <% unless [false, nil, :undefined, :undef, ''].include?(scope.lookupvar('::dns::transfer_source')) -%>
 transfer-source <%= scope.lookupvar('::dns::transfer_source') %> <% unless [false, nil, :undefined, :undef, ''].include?(scope.lookupvar('::dns::transfer_source_port')) %> port <%= scope.lookupvar('::dns::transfer_source_port') %><% end -%>;

--- a/templates/options.conf.erb
+++ b/templates/options.conf.erb
@@ -19,6 +19,15 @@ notify <%= scope.lookupvar('::dns::dns_notify') %>;
 <% unless [false, nil, :undefined, :undef, ''].include?(scope.lookupvar('::dns::listen_on_v6')) -%>
 listen-on-v6 { <%= scope.lookupvar('::dns::listen_on_v6') %>; };
 <% end -%>
+<% unless [false, nil, :undefined, :undef, ''].include?(scope.lookupvar('::dns::listen_on_53')) -%>
+listen-on port 53 { <%= scope.lookupvar('::dns::listen_on_53') %>; };
+<% end -%>
+<% unless [false, nil, :undefined, :undef, ''].include?(scope.lookupvar('::dns::transfert_source')) -%>
+transfert-source <%= scope.lookupvar('::dns::transfert_source') %> <% unless [false, nil, :undefined, :undef, ''].include?(scope.lookupvar('::dns::transfert_source_port')) %> port <%= scope.lookupvar('::dns::transfert_source_port') %><% end -%>;
+<% end -%>
+<% unless [false, nil, :undefined, :undef, ''].include?(scope.lookupvar('::dns::notify_source')) -%>
+notify-source <%= scope.lookupvar('::dns::notify_source') %> <% unless [false, nil, :undefined, :undef, ''].include?(scope.lookupvar('::dns::notify_source_port')) %> port <%= scope.lookupvar('::dns::notify_source_port') %><% end -%>;
+<% end -%>
 
 <% unless scope.lookupvar('::dns::allow_recursion').empty? -%>
 allow-recursion { <%= scope.lookupvar('::dns::allow_recursion').join("; ") %>; };

--- a/templates/options.conf.erb
+++ b/templates/options.conf.erb
@@ -19,8 +19,8 @@ notify <%= scope.lookupvar('::dns::dns_notify') %>;
 <% unless [false, nil, :undefined, :undef, ''].include?(scope.lookupvar('::dns::listen_on_v6')) -%>
 listen-on-v6 { <%= scope.lookupvar('::dns::listen_on_v6') %>; };
 <% end -%>
-<% unless [false, nil, :undefined, :undef, ''].include?(scope.lookupvar('::dns::listen_on_53')) -%>
-listen-on port 53 { <%= scope.lookupvar('::dns::listen_on_53') %>; };
+<% unless [false, nil, :undefined, :undef, ''].include?(scope.lookupvar('::dns::listen_on_v4')) -%>
+listen-on port 53 { <%= scope.lookupvar('::dns::listen_on_v4') %>; };
 <% end -%>
 <% unless [false, nil, :undefined, :undef, ''].include?(scope.lookupvar('::dns::transfer_source')) -%>
 transfer-source <%= scope.lookupvar('::dns::transfer_source') %> <% unless [false, nil, :undefined, :undef, ''].include?(scope.lookupvar('::dns::transfer_source_port')) %> port <%= scope.lookupvar('::dns::transfer_source_port') %><% end -%>;

--- a/templates/options.conf.erb
+++ b/templates/options.conf.erb
@@ -22,8 +22,8 @@ listen-on-v6 { <%= scope.lookupvar('::dns::listen_on_v6') %>; };
 <% unless [false, nil, :undefined, :undef, ''].include?(scope.lookupvar('::dns::listen_on_53')) -%>
 listen-on port 53 { <%= scope.lookupvar('::dns::listen_on_53') %>; };
 <% end -%>
-<% unless [false, nil, :undefined, :undef, ''].include?(scope.lookupvar('::dns::transfert_source')) -%>
-transfert-source <%= scope.lookupvar('::dns::transfert_source') %> <% unless [false, nil, :undefined, :undef, ''].include?(scope.lookupvar('::dns::transfert_source_port')) %> port <%= scope.lookupvar('::dns::transfert_source_port') %><% end -%>;
+<% unless [false, nil, :undefined, :undef, ''].include?(scope.lookupvar('::dns::transfer_source')) -%>
+transfer-source <%= scope.lookupvar('::dns::transfer_source') %> <% unless [false, nil, :undefined, :undef, ''].include?(scope.lookupvar('::dns::transfer_source_port')) %> port <%= scope.lookupvar('::dns::transfer_source_port') %><% end -%>;
 <% end -%>
 <% unless [false, nil, :undefined, :undef, ''].include?(scope.lookupvar('::dns::notify_source')) -%>
 notify-source <%= scope.lookupvar('::dns::notify_source') %> <% unless [false, nil, :undefined, :undef, ''].include?(scope.lookupvar('::dns::notify_source_port')) %> port <%= scope.lookupvar('::dns::notify_source_port') %><% end -%>;


### PR DESCRIPTION
I add some variables in the config file like the listen-on (for example when you server get multiple ip address and you don't want bind listen on all interface), same problem for notify_source and transfert_source. 

I think it's better not to put that inside a additionnel_options because it's 3 fields. 