### PR TITLE
add additional_directives parameter for top-scope bind directives in named.conf

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,33 +22,34 @@
 #     include dns
 #
 class dns (
-  $namedconf_path       = $::dns::params::namedconf_path,
-  $dnsdir               = $::dns::params::dnsdir,
-  $dns_server_package   = $::dns::params::dns_server_package,
-  $rndckeypath          = $::dns::params::rndckeypath,
-  $optionspath          = $::dns::params::optionspath,
-  $publicviewpath       = $::dns::params::publicviewpath,
-  $vardir               = $::dns::params::vardir,
-  $namedservicename     = $::dns::params::namedservicename,
-  $zonefilepath         = $::dns::params::zonefilepath,
-  $localzonepath        = $::dns::params::localzonepath,
-  $forward              = $::dns::params::forward,
-  $forwarders           = $::dns::params::forwarders,
-  $listen_on_v6         = $::dns::params::listen_on_v6,
-  $recursion            = $::dns::params::recursion,
-  $allow_recursion      = $::dns::params::allow_recursion,
-  $allow_query          = $::dns::params::allow_query,
-  $empty_zones_enable   = $::dns::params::empty_zones_enable,
-  $dns_notify           = $::dns::params::dns_notify,
-  $dnssec_enable        = $::dns::params::dnssec_enable,
-  $dnssec_validation    = $::dns::params::dnssec_validation,
-  $namedconf_template   = $::dns::params::namedconf_template,
-  $acls                 = $::dns::params::acls,
-  $optionsconf_template = $::dns::params::optionsconf_template,
-  $controls             = $::dns::params::controls,
-  $service_ensure       = $::dns::params::service_ensure,
-  $service_enable       = $::dns::params::service_enable,
-  $additional_options   = $::dns::params::additional_options,
+  $namedconf_path        = $::dns::params::namedconf_path,
+  $dnsdir                = $::dns::params::dnsdir,
+  $dns_server_package    = $::dns::params::dns_server_package,
+  $rndckeypath           = $::dns::params::rndckeypath,
+  $optionspath           = $::dns::params::optionspath,
+  $publicviewpath        = $::dns::params::publicviewpath,
+  $vardir                = $::dns::params::vardir,
+  $namedservicename      = $::dns::params::namedservicename,
+  $zonefilepath          = $::dns::params::zonefilepath,
+  $localzonepath         = $::dns::params::localzonepath,
+  $forward               = $::dns::params::forward,
+  $forwarders            = $::dns::params::forwarders,
+  $listen_on_v6          = $::dns::params::listen_on_v6,
+  $recursion             = $::dns::params::recursion,
+  $allow_recursion       = $::dns::params::allow_recursion,
+  $allow_query           = $::dns::params::allow_query,
+  $empty_zones_enable    = $::dns::params::empty_zones_enable,
+  $dns_notify            = $::dns::params::dns_notify,
+  $dnssec_enable         = $::dns::params::dnssec_enable,
+  $dnssec_validation     = $::dns::params::dnssec_validation,
+  $namedconf_template    = $::dns::params::namedconf_template,
+  $acls                  = $::dns::params::acls,
+  $optionsconf_template  = $::dns::params::optionsconf_template,
+  $controls              = $::dns::params::controls,
+  $service_ensure        = $::dns::params::service_ensure,
+  $service_enable        = $::dns::params::service_enable,
+  $additional_options    = $::dns::params::additional_options,
+  $additional_directives = $::dns::params::additional_directives,
 ) inherits dns::params {
   validate_array($dns::forwarders)
   validate_array($dns::allow_recursion)
@@ -67,6 +68,7 @@ class dns (
   validate_hash($controls)
   validate_hash($acls)
   validate_hash($additional_options)
+  validate_array($additional_directives)
 
   class { '::dns::install': } ~>
   class { '::dns::config': } ~>

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -58,36 +58,37 @@ class dns::params {
       }
     }
 
-    $namedconf_template   = 'dns/named.conf.erb'
-    $optionsconf_template = 'dns/options.conf.erb'
+    $namedconf_template    = 'dns/named.conf.erb'
+    $optionsconf_template  = 'dns/options.conf.erb'
 
-    $namedconf_path       = "${dnsdir}/named.conf"
+    $namedconf_path        = "${dnsdir}/named.conf"
 
     #pertaining to rndc
-    $rndckeypath          = "${dnsdir}/rndc.key"
+    $rndckeypath           = "${dnsdir}/rndc.key"
 
-    $forward              = undef
-    $forwarders           = []
+    $forward               = undef
+    $forwarders            = []
 
-    $listen_on_v6         = 'any'
+    $listen_on_v6          = 'any'
 
-    $recursion            = 'yes'
-    $allow_recursion      = [ 'localnets', 'localhost' ]
-    $allow_query          = [ 'any' ]
+    $recursion             = 'yes'
+    $allow_recursion       = [ 'localnets', 'localhost' ]
+    $allow_query           = [ 'any' ]
 
-    $empty_zones_enable   = 'yes'
+    $empty_zones_enable    = 'yes'
 
-    $dns_notify           = undef
+    $dns_notify            = undef
 
-    $dnssec_enable        = 'yes'
-    $dnssec_validation    = 'yes'
+    $dnssec_enable         = 'yes'
+    $dnssec_validation     = 'yes'
 
-    $controls             = { '127.0.0.1' => { 'port' => 953, 'allowed_addresses' => [ '127.0.0.1' ], 'keys' => [ 'rndc-key' ] }, }
+    $controls              = { '127.0.0.1' => { 'port' => 953, 'allowed_addresses' => [ '127.0.0.1' ], 'keys' => [ 'rndc-key' ] }, }
 
-    $service_ensure       = 'running'
-    $service_enable       = true
-    $acls                 = {}
+    $service_ensure        = 'running'
+    $service_enable        = true
+    $acls                  = {}
 
-    $additional_options   = {}
+    $additional_options    = {}
+    $additional_directives = []
 
 }

--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -23,6 +23,12 @@ acl "<%= acl_name %>"  {
         <%- end -%>
 };
 <%- end -%>
+<%- if scope.lookupvar('::dns::additional_directives').any? -%>
+// additional directives
+<%- scope.lookupvar('::dns::additional_directives').each do |directive| -%>
+<%= directive %>
+<%- end -%>
+<%- end -%>
 
 // Public view read by Server Admin
 include "<%= scope.lookupvar('::dns::publicviewpath') %>";


### PR DESCRIPTION
As discussed in https://github.com/theforeman/puppet-dns/pull/72 here comes a version with a loop inside the template which injects the `additional_directives` content into named.conf.