### PR TITLE
Move chaining arrows to right operand line

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -42,8 +42,8 @@ class dns::config {
   exec { 'create-rndc.key':
     command => "${dns::rndcconfgen} -r /dev/urandom -a -c ${dns::rndckeypath}",
     creates => $dns::rndckeypath,
-  } ->
-  file { $dns::rndckeypath:
+  }
+  -> file { $dns::rndckeypath:
     owner => 'root',
     group => $dns::params::group,
     mode  => '0640',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -149,8 +149,8 @@ class dns (
   validate_hash($additional_options)
   validate_array($additional_directives)
 
-  class { '::dns::install': } ~>
-  class { '::dns::config': } ~>
-  class { '::dns::service': } ->
-  Class['dns']
+  class { '::dns::install': }
+  ~> class { '::dns::config': }
+  ~> class { '::dns::service': }
+  ~> Class['dns']
 }


### PR DESCRIPTION
To match style guide and for compatibility with puppet-lint 2.2.0.