### PR TITLE
Use contain for chaining

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -130,10 +130,11 @@ class dns (
   Hash[String, Hash] $zones                                       = $::dns::params::zones,
 ) inherits dns::params {
 
-  class { '::dns::install': }
-  ~> class { '::dns::config': }
-  ~> class { '::dns::service': }
-  ~> Class['dns']
+  include ::dns::install
+  include ::dns::config
+  contain ::dns::service
+
+  Class['dns::install'] ~> Class['dns::config'] ~> Class['dns::service']
 
   create_resources('dns::zone', $zones)
 }

--- a/spec/classes/dns_init_spec.rb
+++ b/spec/classes/dns_init_spec.rb
@@ -227,6 +227,7 @@ describe 'dns' do
         }
       end
 
+      it { should compile.with_all_deps }
       it { should contain_dns__zone('example.com') }
     end
   end


### PR DESCRIPTION
This prevents a cyclic dependency when using the zones parameter.