### PR TITLE
Adds control keys and specifying update policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Zones can be created with the `dns::zone` resource:
 
     dns::zone { 'example.com': }
 
+Keys can be created with the `dns::key` resource:
+
+    dns::key {'dns-key':}
+
 Slaves can also be configured by setting `allow_transfer` in the master's zone
 and setting `zonetype => 'slave'` in the slave's zone.
 

--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -1,0 +1,42 @@
+# Generate a new key for the dns
+#
+# === Parameters:
+#
+# $secret::                     This is the secret to be place inside the keyfile, if left empty the key will be generated
+#    
+define dns::key(
+  String               $algorithm    = 'hmac-md5',
+  String               $filename     = "${name}.key",
+  Optional[String]     $secret       = undef,
+  Stdlib::Absolutepath $keydir       = $::dns::dnsdir,
+  Integer              $keysize      = 512,
+) {
+  $keyfilename = "${keydir}/${filename}"
+
+  if $secret {
+    file {$keyfilename:
+      ensure  => file,
+      owner   => $dns::user,
+      group   => $dns::group,
+      mode    => '0640',
+      content => template('dns/key.erb'),
+      notify  => Service[$::dns::namedservicename],
+    }
+  } else {
+    exec { "create-${filename}":
+      command => "${dns::rndcconfgen} -r /dev/urandom -a -c ${keyfilename} -b ${keysize} -k ${name}",
+      creates => $keyfilename,
+      notify  => Service[$::dns::namedservicename],
+    }-> file { $keyfilename:
+      owner => 'root',
+      group => $dns::params::group,
+      mode  => '0640',
+    }
+  }
+
+  concat::fragment { "named.conf+20-key-${name}.dns":
+    target  => $::dns::namedconf_path,
+    content => "include \"${keyfilename}\";\n",
+    order   => '20',
+  }
+}

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -6,31 +6,37 @@
 #
 # $manage_file_name::           Whether to set the file parameter in the zone file.
 #
+# $update_policy_rules::        This can be used to specifiy additional update policy rules in the following format
+#                               { '<KEY_NAME' => {'matchtype' => '<VALUE>', 'tname' => '<VALUE>', 'rr' => 'VALUE' } }
+#                               Example {'foreman_key' => {'matchtype' => 'zonesub', 'rr' => 'ANY'}}
+#                               tname and rr are optional
+#
 define dns::zone (
-  Array[String] $target_views                         = [],
-  String $zonetype                                    = 'master',
-  String $soa                                         = $::fqdn,
-  Boolean $reverse                                    = false,
-  String $ttl                                         = '10800',
-  Stdlib::Compat::Ip_address $soaip                   = $::ipaddress,
-  Integer $refresh                                    = 86400,
-  Integer $update_retry                               = 3600,
-  Integer $expire                                     = 604800,
-  Integer $negttl                                     = 3600,
-  Integer $serial                                     = 1,
-  Array $masters                                      = [],
-  Array $allow_transfer                               = [],
-  Array $allow_query                                  = [],
-  Array $also_notify                                  = [],
-  String $zone                                        = $title,
-  Optional[String] $contact                           = undef,
-  Stdlib::Absolutepath $zonefilepath                  = $::dns::zonefilepath,
-  String $filename                                    = "db.${title}",
-  Boolean $manage_file                                = true,
-  Boolean $manage_file_name                           = false,
-  Enum['first', 'only'] $forward                      = 'first',
-  Array $forwarders                                   = [],
-  Optional[Enum['yes', 'no', 'explicit']] $dns_notify = undef,
+  Array[String] $target_views                           = [],
+  String $zonetype                                      = 'master',
+  String $soa                                           = $::fqdn,
+  Boolean $reverse                                      = false,
+  String $ttl                                           = '10800',
+  Stdlib::Compat::Ip_address $soaip                     = $::ipaddress,
+  Integer $refresh                                      = 86400,
+  Integer $update_retry                                 = 3600,
+  Integer $expire                                       = 604800,
+  Integer $negttl                                       = 3600,
+  Integer $serial                                       = 1,
+  Array $masters                                        = [],
+  Array $allow_transfer                                 = [],
+  Array $allow_query                                    = [],
+  Array $also_notify                                    = [],
+  String $zone                                          = $title,
+  Optional[String] $contact                             = undef,
+  Stdlib::Absolutepath $zonefilepath                    = $::dns::zonefilepath,
+  String $filename                                      = "db.${title}",
+  Boolean $manage_file                                  = true,
+  Boolean $manage_file_name                             = false,
+  Enum['first', 'only'] $forward                        = 'first',
+  Array $forwarders                                     = [],
+  Optional[Enum['yes', 'no', 'explicit']] $dns_notify   = undef,
+  Hash[String, Hash[String, Data]] $update_policy_rules = {},
 ) {
 
   $_contact = pick($contact, "root.${zone}.")

--- a/spec/defines/dns_key_spec.rb
+++ b/spec/defines/dns_key_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe 'dns::key' do
+  let(:facts) do
+    {
+      :clientcert     => 'puppetmaster.example.com',
+      :concat_basedir => '/doesnotexist',
+      :fqdn           => 'puppetmaster.example.com',
+      :ipaddress      => '192.168.1.1',
+      :osfamily       => 'RedHat',
+    }
+  end
+
+  let(:title) { 'foreman_key' }
+
+  let :pre_condition do
+    'include dns'
+  end
+
+  it { is_expected.to compile }
+  it { is_expected.to contain_exec('create-foreman_key.key') }
+
+  context 'secret set' do
+    let(:params) do
+      {
+        :secret => 'top_secret',
+      }
+    end
+    it 'should contain a file with the secret in it' do
+      is_expected.to contain_file('/etc/foreman_key.key')
+      verify_contents(catalogue, '/etc/foreman_key.key', [
+        'key "foreman_key" {',
+        '    algorithm hmac-md5;',
+        '    secret "top_secret";',
+        '};',
+      ])
+      verify_concat_fragment_exact_contents(catalogue, 'named.conf+20-key-foreman_key.dns', [
+        'include "/etc/foreman_key.key";',
+      ])
+
+    end
+  end
+end

--- a/spec/defines/dns_zone_spec.rb
+++ b/spec/defines/dns_zone_spec.rb
@@ -263,4 +263,20 @@ describe 'dns::zone' do
 
   end
 
+  context 'update_policy_rules is set' do
+    let(:params) { {
+      :update_policy_rules => {
+        'foreman_key' => {
+          'matchtype' => 'zonesub',
+          'tname' => '*',
+          'rr' => 'ANY'
+        }
+      }
+    } }
+
+    it "should have valid slave zone configuration" do
+      is_expected.to compile
+    end
+  end
+
 end

--- a/templates/key.erb
+++ b/templates/key.erb
@@ -1,0 +1,4 @@
+key "<%= @name %>" {
+    algorithm <%= @algorithm %>;
+    secret "<%= @secret %>";
+};

--- a/templates/named.zone.erb
+++ b/templates/named.zone.erb
@@ -12,6 +12,9 @@ zone "<%= @zone %>" {
 <% if @zonetype == 'master' -%>
     update-policy {
             grant rndc-key zonesub ANY;
+            <%- @update_policy_rules.sort_by {|k, v| k}.each do |key, key_hash| -%>
+            grant <%= key %> <%= key_hash['matchtype'] %> <% if key_hash['tname'] %><%= key_hash['tname'] %> <% end %><% if key_hash['rr'] %><%= key_hash['rr'] %><% end %>;
+            <%- end -%>
     };
 <% end -%>
 <% unless @allow_transfer.empty? -%>


### PR DESCRIPTION
Fixes GH-94
This commit adds a new resource type key, which creates a rndc key which can be used to control bind using nsupdate.
Also this commit allows to specify update policy rules for zones.

I see that the beaker tests are failing and I also have not written a beaker test for this one.
Please let me know a beaker test is required.