### PR TITLE
[WIP] Use sudo: required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,4 +34,4 @@ matrix:
       services: docker
       bundler_args: --without development
 bundler_args: --without system_tests development
-sudo: false
+sudo: required


### PR DESCRIPTION
Travis support suggested this although I think it won't matter because
https://docs.travis-ci.com/user/docker/ states it's implicit when
services: docker is used.