### PR TITLE
Remove redundant symlink

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,6 +2,3 @@ fixtures:
   repositories:
     concat:      'https://github.com/puppetlabs/puppetlabs-concat'
     stdlib:      'https://github.com/puppetlabs/puppetlabs-stdlib.git'
-
-  symlinks:
-    dns: "#{source_dir}"


### PR DESCRIPTION
With recent versions of puppetlabs_spec_helper this is done automatically