### PR TITLE
feat: add keys parameter and create_resources accordingly

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -84,6 +84,9 @@
 # $zones::                      A hash of zones to be created. See dns::zone
 #                               for options.
 #
+# $keys::                       A hash of keys to be created. See dns::key for
+#                               options.
+#
 # === Usage:
 #
 # * Simple usage:
@@ -122,6 +125,7 @@ class dns (
   Array[String] $additional_directives                              = $dns::params::additional_directives,
   Boolean $enable_views                                             = $dns::params::enable_views,
   Hash[String, Hash] $zones                                         = $dns::params::zones,
+  Hash[String, Hash] $keys                                          = $dns::params::keys,
 ) inherits dns::params {
 
   include dns::install
@@ -130,5 +134,6 @@ class dns (
 
   Class['dns::install'] ~> Class['dns::config'] ~> Class['dns::service']
 
+  create_resources('dns::key', $keys)
   create_resources('dns::zone', $zones)
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -108,4 +108,5 @@ class dns::params {
   $additional_directives = []
 
   $zones                 = {}
+  $keys                  = {}
 }

--- a/spec/classes/dns_init_spec.rb
+++ b/spec/classes/dns_init_spec.rb
@@ -230,6 +230,19 @@ describe 'dns' do
       it { should compile.with_all_deps }
       it { should contain_dns__zone('example.com') }
     end
+
+    describe 'with keys' do
+      let :params do
+        {
+          :keys => {
+            'dns-key' => {},
+          },
+        }
+      end
+
+      it { should compile.with_all_deps }
+      it { should contain_dns__key('dns-key') }
+    end
   end
 
   describe 'on FreeBSD with no custom parameters' do


### PR DESCRIPTION
Thanks to #108 we can use custom keys :+1: 

We wanted to take it a step further and use the same method for the keys that exists for the zones: `create_resources` via a hash.

This PR achieves this.

Thanks to [Erasys GmbH](http://www.erasys.de/) for their support