### PR TITLE
Make managing BIND system group optional

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,7 +1,9 @@
 # Configure dns
 # @api private
 class dns::config {
-  group { $dns::params::group: }
+  if $dns::group_manage {
+    group { $dns::params::group: }
+  }
 
   concat { $dns::publicviewpath:
     owner => root,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,6 +14,10 @@
 #   Path of the config file holding all the zones
 # @param vardir
 #   Directory holding the variable or working files
+# @param group_manage
+#   Should this module manage the Unix system group under which BIND runs (see
+#   dns::params)?  Defaults to true. Set to false if you want to manage the
+#   system group yourself.
 # @param namedservicename
 #   Name of the service
 # @param zonefilepath
@@ -85,6 +89,7 @@ class dns (
   Stdlib::Absolutepath $optionspath                                 = $dns::params::optionspath,
   Stdlib::Absolutepath $publicviewpath                              = $dns::params::publicviewpath,
   Stdlib::Absolutepath $vardir                                      = $dns::params::vardir,
+  Boolean $group_manage                                             = $dns::params::group_manage,
   String $namedservicename                                          = $dns::params::namedservicename,
   Stdlib::Absolutepath $zonefilepath                                = $dns::params::zonefilepath,
   Variant[Enum['unmanaged'], Stdlib::Absolutepath] $localzonepath   = $dns::params::localzonepath,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -67,6 +67,9 @@ class dns::params {
     }
   }
 
+  # This module will manage the system group by default
+  $group_manage = true
+
   $namedconf_template    = 'dns/named.conf.erb'
   $optionsconf_template  = 'dns/options.conf.erb'
 

--- a/spec/classes/dns_init_spec.rb
+++ b/spec/classes/dns_init_spec.rb
@@ -20,6 +20,7 @@ describe 'dns' do
       it { should contain_class('dns::service') }
 
       it { should contain_package('bind').with_ensure('present') }
+      it { should contain_group('named') }
 
       it { should contain_concat('/etc/named/options.conf') }
       it { verify_concat_fragment_contents(catalogue, 'options.conf+10-main.dns', [
@@ -181,6 +182,11 @@ describe 'dns' do
       it { should contain_service('named').with_ensure('running').with_enable(false) }
     end
 
+    describe 'with group_manage false' do
+      let(:params) { {:group_manage => false} }
+      it { should_not contain_group('named') }
+    end
+
     describe 'with acls set' do
       let(:params) { {:acls => { 'trusted_nets' => [ '127.0.0.1/24', '127.0.1.0/24' ] } } }
       it { verify_concat_fragment_exact_contents(catalogue, 'named.conf+10-main.dns', [
@@ -262,6 +268,7 @@ describe 'dns' do
       it { should contain_class('dns::service') }
 
       it { should contain_package('bind910').with_ensure('present') }
+      it { should contain_group('bind') }
 
       it { should contain_concat('/usr/local/etc/namedb/options.conf') }
       it { verify_concat_fragment_contents(catalogue, 'options.conf+10-main.dns', [
@@ -303,6 +310,11 @@ describe 'dns' do
     describe 'with service_enable false' do
       let(:params) { {:service_enable => false} }
       it { should contain_service('named').with_ensure('running').with_enable(false) }
+    end
+
+    describe 'with group_manage false' do
+      let(:params) { {:group_manage => false} }
+      it { should_not contain_group('bind') }
     end
   end
 end


### PR DESCRIPTION
Add class parameter dns::group_manage which defaults to true, so that
the module keeps managing the system group for BIND ("bind" or "named"),
but allow the user to set it to false. This way the group can be managed
outside of this module's scope.

Fixes GH-140