### PR TITLE
Allow setting service restart command

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -93,6 +93,14 @@
 #   The ensure attribute on the service
 # @param service_enable
 #   Whether to enable the service (start at boot)
+# @param service_restart_command
+#   Custom command to use when the service will be restarted (notified by
+#   configuration changes). Will be passed directly to the restart parameter of
+#   the contained service resource. This is useful when you want BIND to reload
+#   its configuration instead of restarting the whole process, for example by
+#   setting `service_restart_command` to `/usr/sbin/service bind9 reload` or
+#   `/usr/sbin/rndc reload` or even `/usr/bin/systemctl try-reload-or-restart bind9`.
+#   Default is 'undef' so the service resource default is used.
 # @param additional_options
 #   Additional options
 # @param additional_directives
@@ -143,6 +151,7 @@ class dns (
   Hash[String, Hash[String, Data]] $controls                        = $dns::params::controls,
   Variant[Enum['running', 'stopped'], Boolean] $service_ensure      = $dns::params::service_ensure,
   Boolean $service_enable                                           = $dns::params::service_enable,
+  Optional[String[1]] $service_restart_command                      = $dns::params::service_restart_command,
   Hash[String, Data] $additional_options                            = $dns::params::additional_options,
   Array[String] $additional_directives                              = $dns::params::additional_directives,
   Boolean $enable_views                                             = $dns::params::enable_views,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -96,6 +96,11 @@ class dns::params {
   # This module will manage the system group by default
   $group_manage = true
 
+  # Don't set any restart command by default, let Puppet use the
+  # platform-dependent service resource default when handling the service
+  # restart.
+  $service_restart_command = undef
+
   $namedconf_template    = 'dns/named.conf.erb'
   $optionsconf_template  = 'dns/options.conf.erb'
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -6,5 +6,6 @@ class dns::service {
     enable     => $dns::service_enable,
     hasstatus  => true,
     hasrestart => true,
+    restart    => $dns::service_restart_command,
   }
 }

--- a/spec/classes/dns_init_spec.rb
+++ b/spec/classes/dns_init_spec.rb
@@ -83,7 +83,7 @@ describe 'dns' do
         )
       }
 
-      it { should contain_service('named').with_ensure('running').with_enable(true) }
+      it { should contain_service('named').with_ensure('running').with_enable(true).with_restart(nil) }
     end
 
     describe 'with unmanaged localzonepath' do
@@ -210,6 +210,16 @@ describe 'dns' do
     describe 'with service_enable false' do
       let(:params) { {:service_enable => false} }
       it { should contain_service('named').with_ensure('running').with_enable(false) }
+    end
+
+    describe 'with service_restart_command set to "/usr/sbin/service bind9 reload' do
+      let(:params) { {:service_restart_command => '/usr/sbin/service bind9 reload'} }
+      it {
+        should contain_service('named')
+          .with_ensure('running')
+          .with_enable(true)
+          .with_restart('/usr/sbin/service bind9 reload')
+      }
     end
 
     describe 'with group_manage false' do


### PR DESCRIPTION
By default the service resource that manages the BIND service will
restart the service when notified by configuration changes. This can be
disruptive.

This change allows the user to set a custom restart command via
`dns::service_restart_command` for the service resource, such as
`/usr/sbin/service bind9 reload` or `/bin/systemctl reload bind9.service`
or even `/usr/sbin/rndc reload`, to avoid restarting the whole named
process. By default no restart command is set.