### PR TITLE
Validate named.conf and zones.conf using named-checkconf

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,9 +6,10 @@ class dns::config {
   }
 
   concat { $dns::publicviewpath:
-    owner => root,
-    group => $dns::params::group,
-    mode  => '0640',
+    owner        => root,
+    group        => $dns::params::group,
+    mode         => '0640',
+    validate_cmd => "${dns::named_checkconf} %",
   }
 
   if $dns::enable_views {
@@ -19,13 +20,24 @@ class dns::config {
       mode   => '0755',
     }
   }
+
   concat::fragment { 'dns_zones+01-header.dns':
     target  => $dns::publicviewpath,
     content => ' ',
     order   => '01',
   }
 
-  concat { [$dns::namedconf_path, $dns::optionspath]:
+  concat { $dns::namedconf_path:
+    owner        => root,
+    group        => $dns::params::group,
+    mode         => '0640',
+    require      => Concat[$dns::optionspath],
+    validate_cmd => "${dns::named_checkconf} %",
+  }
+
+  # This file cannot be checked by named-checkconf because its content is only
+  # valid inside an "options { };" directive.
+  concat { $dns::optionspath:
     owner => root,
     group => $dns::params::group,
     mode  => '0640',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,6 +16,7 @@ class dns::params {
       $user               = 'bind'
       $group              = 'bind'
       $rndcconfgen        = '/usr/sbin/rndc-confgen'
+      $named_checkconf    = '/usr/sbin/named-checkconf'
       $sysconfig_file     = '/etc/default/bind9'
       $sysconfig_template = "dns/sysconfig.${facts['osfamily']}.erb"
       $sysconfig_startup_options = '-u bind'
@@ -38,6 +39,7 @@ class dns::params {
       $user               = 'named'
       $group              = 'named'
       $rndcconfgen        = '/usr/sbin/rndc-confgen'
+      $named_checkconf    = '/usr/sbin/named-checkconf'
       $sysconfig_file     = '/etc/sysconfig/named'
       $sysconfig_template = "dns/sysconfig.${facts['osfamily']}.erb"
       $sysconfig_startup_options = undef
@@ -60,6 +62,7 @@ class dns::params {
       $user               = 'bind'
       $group              = 'bind'
       $rndcconfgen        = '/usr/local/sbin/rndc-confgen'
+      $named_checkconf    = '/usr/local/sbin/named-checkconf'
       # The sysconfig settings are not relevant for FreeBSD
       $sysconfig_file     = undef
       $sysconfig_template = undef
@@ -81,6 +84,7 @@ class dns::params {
       $user               = 'named'
       $group              = 'named'
       $rndcconfgen        = '/usr/sbin/rndc-confgen'
+      $named_checkconf    = '/usr/sbin/named-checkconf'
       # The sysconfig settings are not relevant for ArchLinux
       $sysconfig_file     = undef
       $sysconfig_template = undef

--- a/manifests/view.pp
+++ b/manifests/view.pp
@@ -36,6 +36,7 @@ define dns::view (
     group  => $dns::params::group,
     mode   => '0640',
     notify => Service[$dns::namedservicename],
+    before => Concat[$dns::publicviewpath],
   }
 
   concat::fragment { "dns_view_header_${title}.dns":

--- a/spec/classes/dns_init_spec.rb
+++ b/spec/classes/dns_init_spec.rb
@@ -34,7 +34,8 @@ describe 'dns' do
           'allow-recursion { localnets; localhost; };'
       ])}
 
-      it { should contain_concat('/etc/named.conf') }
+      it { should contain_concat('/etc/named/zones.conf').with_validate_cmd('/usr/sbin/named-checkconf %') }
+      it { should contain_concat('/etc/named.conf').with_validate_cmd('/usr/sbin/named-checkconf %') }
       it { verify_concat_fragment_exact_contents(catalogue, 'named.conf+10-main.dns', [
           '// named.conf',
           'include "/etc/rndc.key";',
@@ -406,7 +407,8 @@ export SOMETHING="other"
            'allow-recursion { localnets; localhost; };'
       ])}
 
-      it { should contain_concat('/usr/local/etc/namedb/named.conf') }
+      it { should contain_concat('/usr/local/etc/namedb/zones.conf').with_validate_cmd('/usr/local/sbin/named-checkconf %') }
+      it { should contain_concat('/usr/local/etc/namedb/named.conf').with_validate_cmd('/usr/local/sbin/named-checkconf %') }
       it { verify_concat_fragment_exact_contents(catalogue, 'named.conf+10-main.dns', [
           '// named.conf',
           'include "/usr/local/etc/namedb/rndc.key";',


### PR DESCRIPTION
Make use of the `validate_cmd` parameter in concat to run
named-checkconf on the target file. This way the validity of to-be-updated
configuration files named.conf or zones.conf is checked before actually
writing the new configuration and restarting the named service. This
prevents named from loading invalid configuration settings that would
result in named failing to start.

The file named.conf.options itself cannot be checked with
named-checkconf because its content is only valid inside the
"options { };" directive.