### PR TITLE
Add support for managing sysconfig settings

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -59,4 +59,18 @@ class dns::config {
     group => $dns::params::group,
     mode  => '0640',
   }
+
+  # Only Debian and RedHat OS provide a sysconfig or default file where we can
+  # set startup options and other environment settings for named. In FreeBSD
+  # such settings must be set in the global, common /etc/rc.conf file and under
+  # ArchLinux we must use systemd override files to change the startup
+  # commandline. These cases are outside of this module's scope.
+  if $facts['osfamily'] in ['Debian', 'RedHat'] {
+    file { $dns::sysconfig_file:
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+      content => template($dns::sysconfig_template),
+    }
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -58,6 +58,33 @@
 #   an array of subnet strings.
 # @param optionsconf_template
 #   The template to be used for options.conf
+# @param sysconfig_file
+#   Path to the sysconfig or default file used to set startup options for
+#   named. Under Debian this is /etc/default/bind9, under RedHat this is
+#   /etc/sysconfig/named. FreeBSD/DragonFly and ArchLinux do not feature such
+#   files, thus the sysconfig parameters are not relevant for these operating
+#   systems.
+# @param sysconfig_template
+#   The template used to model /etc/default/bind9 or /etc/sysconfig/named.
+#   Default is "dns/sysconfig.${facts[osfamily]}.erb" for Debian and RedHat,
+#   and undef for others.
+# @param sysconfig_startup_options
+#   Startup options for the `named` process, rendered as the `OPTIONS` string
+#   in the sysconfig file (see above). Use this to set commandline flags and
+#   options for `named`. For example, to use IPv4 only and disable IPv6 support
+#   in named on Debian set this parameter to `-u bind -4`. The default value
+#   depends on the underlying OS.
+# @param sysconfig_resolvconf_integration
+#   Should named integrate with resolvconf upon startup? Default is false, and
+#   this only pertains to the Debian OS family.
+# @param sysconfig_disable_zone_checking
+#   Should zone checking be disabled upon named startup? Default is undef, and
+#   this only pertains to the RedHat OS family.
+# @param sysconfig_additional_settings
+#   Additional settings to add to the sysconfig file. This is a simple hash of
+#   key-value strings that will be rendered as `KEY="value"` in the sysconfig
+#   file. Use this to add custom (environment) variables relevant for named.
+#   Default is empty.
 # @param controls
 #   Specify a hash of controls. Each key is the name of a network, and its
 #   value is a hash containing 'port' => integer, 'keys' => array and
@@ -107,6 +134,12 @@ class dns (
   String $namedconf_template                                        = $dns::params::namedconf_template,
   Hash[String, Array[String]] $acls                                 = $dns::params::acls,
   String $optionsconf_template                                      = $dns::params::optionsconf_template,
+  Optional[Stdlib::Absolutepath] $sysconfig_file                    = $dns::params::sysconfig_file,
+  Optional[String] $sysconfig_template                              = $dns::params::sysconfig_template,
+  Optional[String] $sysconfig_startup_options                       = $dns::params::sysconfig_startup_options,
+  Optional[Boolean] $sysconfig_resolvconf_integration               = $dns::params::sysconfig_resolvconf_integration,
+  Optional[Boolean] $sysconfig_disable_zone_checking                = $dns::params::sysconfig_disable_zone_checking,
+  Optional[Hash[String[1], String]] $sysconfig_additional_settings  = $dns::params::sysconfig_additional_settings,
   Hash[String, Hash[String, Data]] $controls                        = $dns::params::controls,
   Variant[Enum['running', 'stopped'], Boolean] $service_ensure      = $dns::params::service_ensure,
   Boolean $service_enable                                           = $dns::params::service_enable,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,6 +16,13 @@ class dns::params {
       $user               = 'bind'
       $group              = 'bind'
       $rndcconfgen        = '/usr/sbin/rndc-confgen'
+      $sysconfig_file     = '/etc/default/bind9'
+      $sysconfig_template = "dns/sysconfig.${facts['osfamily']}.erb"
+      $sysconfig_startup_options = '-u bind'
+      $sysconfig_resolvconf_integration = false
+
+      # This option is not relevant for Debian
+      $sysconfig_disable_zone_checking = undef
     }
     'RedHat': {
       $dnsdir             = '/etc'
@@ -31,6 +38,13 @@ class dns::params {
       $user               = 'named'
       $group              = 'named'
       $rndcconfgen        = '/usr/sbin/rndc-confgen'
+      $sysconfig_file     = '/etc/sysconfig/named'
+      $sysconfig_template = "dns/sysconfig.${facts['osfamily']}.erb"
+      $sysconfig_startup_options = undef
+      $sysconfig_disable_zone_checking = undef
+
+      # This option is not relevant for RedHat
+      $sysconfig_resolvconf_integration = undef
     }
     /^(FreeBSD|DragonFly)$/: {
       $dnsdir             = '/usr/local/etc/namedb'
@@ -46,6 +60,12 @@ class dns::params {
       $user               = 'bind'
       $group              = 'bind'
       $rndcconfgen        = '/usr/local/sbin/rndc-confgen'
+      # The sysconfig settings are not relevant for FreeBSD
+      $sysconfig_file     = undef
+      $sysconfig_template = undef
+      $sysconfig_startup_options = undef
+      $sysconfig_disable_zone_checking = undef
+      $sysconfig_resolvconf_integration = undef
     }
     'Archlinux': {
       $dnsdir             = '/etc'
@@ -61,6 +81,12 @@ class dns::params {
       $user               = 'named'
       $group              = 'named'
       $rndcconfgen        = '/usr/sbin/rndc-confgen'
+      # The sysconfig settings are not relevant for ArchLinux
+      $sysconfig_file     = undef
+      $sysconfig_template = undef
+      $sysconfig_startup_options = undef
+      $sysconfig_disable_zone_checking = undef
+      $sysconfig_resolvconf_integration = undef
     }
     default: {
       fail ("Unsupported operating system family ${facts['osfamily']}")
@@ -72,6 +98,8 @@ class dns::params {
 
   $namedconf_template    = 'dns/named.conf.erb'
   $optionsconf_template  = 'dns/options.conf.erb'
+
+  $sysconfig_additional_settings = {}
 
   $namedconf_path        = "${dnsdir}/named.conf"
 

--- a/templates/sysconfig.Debian.erb
+++ b/templates/sysconfig.Debian.erb
@@ -1,0 +1,14 @@
+# This file is managed by Puppet.
+#
+# run resolvconf?
+<%- v = scope['dns::sysconfig_resolvconf_integration'] ? 'yes' : 'no' -%>
+RESOLVCONF=<%= v %>
+
+# startup options for the server
+OPTIONS="<%= scope['dns::sysconfig_startup_options'] %>"
+<%- unless scope['dns::sysconfig_additional_settings'].empty? -%>
+
+<%- scope['dns::sysconfig_additional_settings'].sort.map do |param, value| -%>
+<%= param %>="<%= value %>"
+<%- end -%>
+<%- end -%>

--- a/templates/sysconfig.RedHat.erb
+++ b/templates/sysconfig.RedHat.erb
@@ -1,0 +1,32 @@
+# This file is managed by Puppet.
+#
+# BIND named process options
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# OPTIONS="whatever"     --  These additional options will be passed to named
+#                            at startup. Don't add -t here, enable proper
+#                            -chroot.service unit file.
+#                            Use of parameter -c is not supported here. Extend
+#                            systemd named*.service instead. For more
+#                            information please read the following KB article:
+#                            https://access.redhat.com/articles/2986001
+#
+# DISABLE_ZONE_CHECKING  --  By default, service file calls named-checkzone
+#                            utility for every zone to ensure all zones are
+#                            valid before named starts. If you set this option
+#                            to 'yes' then service file doesn't perform those
+#                            checks.
+<%- unless scope['dns::sysconfig_startup_options'].nil? -%>
+
+OPTIONS="<%= scope['dns::sysconfig_startup_options'] %>"
+<%- end -%>
+<%- unless scope['dns::sysconfig_disable_zone_checking'].nil? -%>
+<%- v = scope['dns::sysconfig_disable_zone_checking'] ? 'yes' : 'no' -%>
+DISABLE_ZONE_CHECKING="<%= v %>"
+<%- end -%>
+<%- unless scope['dns::sysconfig_additional_settings'].empty? -%>
+
+<%- scope['dns::sysconfig_additional_settings'].sort.map do |param, value| -%>
+<%= param %>="<%= value %>"
+<%- end -%>
+<%- end -%>


### PR DESCRIPTION
Debian and RedHat allow setting startup options and other settings via a
sysconfig/default file (/etc/default/bind9 under Debian and
/etc/sysconfig/named under RedHat). FreeBSD/DragonFly and ArchLinux
don't have a direct equivalent.

This change allows managing sysconfig/default settings under Debian and
RedHat. It is especially useful for setting startup options like `-4` to
disable IPv6 support in named, or setting the debug level with `-d`. The
change adds a few specific `$dns::sysconfig_*` parameters to model the
default behaviour under Debian and RedHat, as well as a
`$dns::sysconfig_additional_settings` hash parameter that allows setting
arbitrary key-value pairs in the sysconfig file.

For FreeBSD/DragonFly and ArchLinux these parameters are all set to
undef and not used anywhere since they feature is no directly equivalent
sysconfig setup.

This change also adds basic spec tests for Debian, including tests for
the sysconfig support introduced here.