### PR TITLE
Add manage_service parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,6 +18,12 @@
 #   Should this module manage the Unix system group under which BIND runs (see
 #   dns::params)?  Defaults to true. Set to false if you want to manage the
 #   system group yourself.
+# @param manage_service
+#   Should this module manage the dns service?
+#   This only applies to the service management (running, stopped) and not to
+#   whether the service should be installed or not.
+#   Calls to "notify => Service['$dns::namedservicename']" will still be
+#   executed
 # @param namedservicename
 #   Name of the service
 # @param zonefilepath
@@ -125,6 +131,7 @@ class dns (
   Stdlib::Absolutepath $publicviewpath                              = $dns::params::publicviewpath,
   Stdlib::Absolutepath $vardir                                      = $dns::params::vardir,
   Boolean $group_manage                                             = $dns::params::group_manage,
+  Boolean $manage_service                                           = $dns::params::manage_service,
   String $namedservicename                                          = $dns::params::namedservicename,
   Stdlib::Absolutepath $zonefilepath                                = $dns::params::zonefilepath,
   Variant[Enum['unmanaged'], Stdlib::Absolutepath] $localzonepath   = $dns::params::localzonepath,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,8 +22,8 @@
 #   Should this module manage the dns service?
 #   This only applies to the service management (running, stopped) and not to
 #   whether the service should be installed or not.
-#   Calls to "notify => Service['$dns::namedservicename']" will still be
-#   executed
+#   IMPORTANT: this will not reload the service after a config change, you'll
+#   have to do that manually or via a separate call to notify
 # @param namedservicename
 #   Name of the service
 # @param zonefilepath

--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -33,13 +33,13 @@ define dns::key(
       group   => $dns::group,
       mode    => '0640',
       content => template('dns/key.erb'),
-      notify  => Service[$dns::namedservicename],
+      notify  => Class['dns::service'],
     }
   } else {
     exec { "create-${filename}":
       command => "${dns::rndcconfgen} -r /dev/urandom -a -c ${keyfilename} -b ${keysize} -k ${name}",
       creates => $keyfilename,
-      notify  => Service[$dns::namedservicename],
+      notify  => Class['dns::service'],
     }-> file { $keyfilename:
       owner => 'root',
       group => $dns::params::group,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -141,6 +141,7 @@ class dns::params {
     },
   }
 
+  $manage_service        = true
   $service_ensure        = 'running'
   $service_enable        = true
   $acls                  = {}

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,11 +1,13 @@
 # Enable and start dns service
 # @api private
 class dns::service {
-  service { $dns::namedservicename:
-    ensure     => $dns::service_ensure,
-    enable     => $dns::service_enable,
-    hasstatus  => true,
-    hasrestart => true,
-    restart    => $dns::service_restart_command,
+  if $dns::manage_service {
+    service { $dns::namedservicename:
+      ensure     => $dns::service_ensure,
+      enable     => $dns::service_enable,
+      hasstatus  => true,
+      hasrestart => true,
+      restart    => $dns::service_restart_command,
+    }
   }
 }

--- a/manifests/view.pp
+++ b/manifests/view.pp
@@ -35,7 +35,7 @@ define dns::view (
     owner  => root,
     group  => $dns::params::group,
     mode   => '0640',
-    notify => Service[$dns::namedservicename],
+    notify => Class['dns::service'],
     before => Concat[$dns::publicviewpath],
   }
 

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -87,7 +87,7 @@ define dns::zone (
       mode    => '0644',
       content => template('dns/zone.header.erb'),
       replace => false,
-      notify  => Service[$dns::namedservicename],
+      notify  => Class['dns::service'],
     }
   }
 }

--- a/spec/classes/dns_init_spec.rb
+++ b/spec/classes/dns_init_spec.rb
@@ -228,6 +228,16 @@ describe 'dns' do
       it { should_not contain_group('named') }
     end
 
+    describe 'with manage_service true' do
+      let(:params) { {:manage_service => true} }
+      it { should contain_service('named') }
+    end
+
+    describe 'with manage_service false' do
+      let(:params) { {:manage_service => false} }
+      it { should_not contain_service('named') }
+    end
+
     describe 'with acls set' do
       let(:params) { {:acls => { 'trusted_nets' => [ '127.0.0.1/24', '127.0.1.0/24' ] } } }
       it { verify_concat_fragment_exact_contents(catalogue, 'named.conf+10-main.dns', [
@@ -453,6 +463,16 @@ export SOMETHING="other"
       let(:params) { {:group_manage => false} }
       it { should_not contain_group('bind') }
     end
+
+    describe 'with manage_service true' do
+      let(:params) { {:manage_service => true} }
+      it { should contain_service('named') }
+    end
+
+    describe 'with manage_service false' do
+      let(:params) { {:manage_service => false} }
+      it { should_not contain_service('named') }
+    end
   end
 
   describe 'on Debian' do
@@ -591,5 +611,16 @@ export SOMETHING="other"
         )
       }
     end
+
+    describe 'with manage_service true' do
+      let(:params) { {:manage_service => true} }
+      it { should contain_service('bind9') }
+    end
+
+    describe 'with manage_service false' do
+      let(:params) { {:manage_service => false} }
+      it { should_not contain_service('bind9') }
+    end
+
   end
 end

--- a/spec/defines/dns_zone_spec.rb
+++ b/spec/defines/dns_zone_spec.rb
@@ -38,8 +38,7 @@ describe 'dns::zone' do
       :group    => 'named',
       :mode     => '0644',
       :replace  => 'false',
-      :notify   => 'Class[Dns::Service]',
-    })
+    }).that_notifies('Class[Dns::Service]')
   end
 
   it "should have valid zone file contents" do

--- a/spec/defines/dns_zone_spec.rb
+++ b/spec/defines/dns_zone_spec.rb
@@ -38,7 +38,7 @@ describe 'dns::zone' do
       :group    => 'named',
       :mode     => '0644',
       :replace  => 'false',
-      :notify   => 'Service[named]',
+      :notify   => 'Class[Dns::Service]',
     })
   end
 


### PR DESCRIPTION
This allows users to decide whether the module should manage the
dns service. The check defaults to true, but in case users want to
manage the service autonomously they can.
This also solves "duplicate declaration" issues when the service
is declared in another .pp file

This does not influence package installation.