### PR TITLE
Refactor soaip in dns::zone

### DIFF
--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -1,4 +1,14 @@
-# Define new zone for the dns
+# @summary Define new zone for the dns
+#
+# @param soaip
+#   The IP address for the SOA. If `reverse` is false, an A record will be
+#   created pointing to this IP address for `$soa`. This only makes sense if
+#   `$soa` is withing this zone and needs glue records.
+#
+# @param soaipv6
+#   The IPv6 address for the SOA. If `reverse` is false, an AAAA record will be
+#   created pointing to this IP address for `$soa`. This only makes sense if
+#   `$soa` is withing this zone and needs glue records.
 #
 # @param manage_file
 #   Whether the manage the file resource. When true $manage_file_name is implied.
@@ -19,7 +29,8 @@ define dns::zone (
   String $soa                                           = $fqdn,
   Boolean $reverse                                      = false,
   String $ttl                                           = '10800',
-  Stdlib::Compat::Ip_address $soaip                     = $ipaddress,
+  Optional[Stdlib::IP::Address::V4] $soaip              = undef,
+  Optional[Stdlib::IP::Address::V6] $soaipv6            = undef,
   Integer $refresh                                      = 86400,
   Integer $update_retry                                 = 3600,
   Integer $expire                                       = 604800,

--- a/spec/acceptance/dns_spec.rb
+++ b/spec/acceptance/dns_spec.rb
@@ -17,7 +17,9 @@ describe 'Scenario: install bind' do
     include dns
 
     dns::zone { 'example.com':
-      soa => 'ns1.example.com',
+      soa     => 'ns1.example.com',
+      soaip   => '192.0.2.1',
+      soaipv6 => '2001:db8::1',
     }
     EOS
   end

--- a/spec/acceptance/views_spec.rb
+++ b/spec/acceptance/views_spec.rb
@@ -31,6 +31,7 @@ describe 'Scenario: install bind with views enabled' do
       dns::zone { 'example.com-v4':
         zone         => 'example.com',
         soa          => 'ns1-v4.example.com',
+        soaip        => '192.0.2.1',
         filename     => 'db.example.com-v4',
         target_views => ['v4'],
       }
@@ -38,6 +39,7 @@ describe 'Scenario: install bind with views enabled' do
       dns::zone { 'example.com-v6':
         zone         => 'example.com',
         soa          => 'ns1-v6.example.com',
+        soaipv6      => '2001:db8::1',
         filename     => 'db.example.com-v6',
         target_views => ['v6'],
       }

--- a/spec/classes/dns_init_spec.rb
+++ b/spec/classes/dns_init_spec.rb
@@ -7,7 +7,6 @@ describe 'dns' do
     let(:facts) do
       {
          :clientcert     => 'puppetmaster.example.com',
-         :concat_basedir => '/doesnotexist',
          :fqdn           => 'puppetmaster.example.com',
          :osfamily       => 'RedHat',
          :ipaddress      => '192.0.2.1',
@@ -402,7 +401,6 @@ export SOMETHING="other"
     let(:facts) do
       {
          :clientcert => 'puppetmaster.example.com',
-         :concat_basedir => '/doesnotexist',
          :fqdn => 'puppetmaster.example.com',
          :osfamily => 'FreeBSD',
       }
@@ -480,7 +478,6 @@ export SOMETHING="other"
     let(:facts) do
       {
          :clientcert     => 'puppetmaster.example.com',
-         :concat_basedir => '/doesnotexist',
          :fqdn           => 'puppetmaster.example.com',
          :osfamily       => 'Debian',
          :ipaddress      => '192.0.2.1',

--- a/spec/classes/dns_init_spec.rb
+++ b/spec/classes/dns_init_spec.rb
@@ -9,7 +9,6 @@ describe 'dns' do
          :clientcert     => 'puppetmaster.example.com',
          :fqdn           => 'puppetmaster.example.com',
          :osfamily       => 'RedHat',
-         :ipaddress      => '192.0.2.1',
       }
     end
 
@@ -480,7 +479,6 @@ export SOMETHING="other"
          :clientcert     => 'puppetmaster.example.com',
          :fqdn           => 'puppetmaster.example.com',
          :osfamily       => 'Debian',
-         :ipaddress      => '192.0.2.1',
       }
     end
 

--- a/spec/defines/dns_key_spec.rb
+++ b/spec/defines/dns_key_spec.rb
@@ -5,7 +5,6 @@ describe 'dns::key' do
     {
       :clientcert     => 'puppetmaster.example.com',
       :fqdn           => 'puppetmaster.example.com',
-      :ipaddress      => '192.168.1.1',
       :osfamily       => 'RedHat',
     }
   end

--- a/spec/defines/dns_key_spec.rb
+++ b/spec/defines/dns_key_spec.rb
@@ -4,7 +4,6 @@ describe 'dns::key' do
   let(:facts) do
     {
       :clientcert     => 'puppetmaster.example.com',
-      :concat_basedir => '/doesnotexist',
       :fqdn           => 'puppetmaster.example.com',
       :ipaddress      => '192.168.1.1',
       :osfamily       => 'RedHat',

--- a/spec/defines/dns_view_spec.rb
+++ b/spec/defines/dns_view_spec.rb
@@ -5,7 +5,6 @@ describe 'dns::view' do
   let(:facts) do
     {
       :clientcert     => 'puppetmaster.example.com',
-      :concat_basedir => '/doesnotexist',
       :fqdn           => 'puppetmaster.example.com',
       :ipaddress      => '192.168.1.1',
       :osfamily       => 'RedHat',

--- a/spec/defines/dns_view_spec.rb
+++ b/spec/defines/dns_view_spec.rb
@@ -6,7 +6,6 @@ describe 'dns::view' do
     {
       :clientcert     => 'puppetmaster.example.com',
       :fqdn           => 'puppetmaster.example.com',
-      :ipaddress      => '192.168.1.1',
       :osfamily       => 'RedHat',
     }
   end

--- a/spec/defines/dns_zone_spec.rb
+++ b/spec/defines/dns_zone_spec.rb
@@ -6,7 +6,6 @@ describe 'dns::zone' do
     {
       :clientcert     => 'puppetmaster.example.com',
       :fqdn           => 'puppetmaster.example.com',
-      :ipaddress      => '192.168.1.1',
       :osfamily       => 'RedHat',
     }
   end
@@ -51,7 +50,6 @@ describe 'dns::zone' do
       '	3600	;Negative caching TTL',
       ')',
       '@ IN NS puppetmaster.example.com.',
-      'puppetmaster.example.com. IN A 192.168.1.1',
     ])
   end
 
@@ -72,6 +70,26 @@ describe 'dns::zone' do
         '@ IN NS puppetmaster.example.com.',
       ])
     end
+  end
+
+  context 'with soaip and soaipv6' do
+    let(:params) { { soaip: '192.0.2.1', soaipv6: '2001:db8::1' } }
+
+  it "should have valid zone file contents" do
+    verify_exact_contents(catalogue, '/var/named/dynamic/db.example.com', [
+      '$TTL 10800',
+      '@ IN SOA puppetmaster.example.com. root.example.com. (',
+      '	1	;Serial',
+      '	86400	;Refresh',
+      '	3600	;Retry',
+      '	604800	;Expire',
+      '	3600	;Negative caching TTL',
+      ')',
+      '@ IN NS puppetmaster.example.com.',
+      'puppetmaster.example.com. IN A 192.0.2.1',
+      'puppetmaster.example.com. IN AAAA 2001:db8::1',
+    ])
+  end
   end
 
   context 'when allow_transfer defined' do

--- a/spec/defines/dns_zone_spec.rb
+++ b/spec/defines/dns_zone_spec.rb
@@ -5,7 +5,6 @@ describe 'dns::zone' do
   let(:facts) do
     {
       :clientcert     => 'puppetmaster.example.com',
-      :concat_basedir => '/doesnotexist',
       :fqdn           => 'puppetmaster.example.com',
       :ipaddress      => '192.168.1.1',
       :osfamily       => 'RedHat',

--- a/templates/zone.header.erb
+++ b/templates/zone.header.erb
@@ -8,6 +8,11 @@ $TTL <%= @ttl %>
 )
 
 @ IN NS <%= @soa %>.
-<% if ! @reverse %>
+<% unless @reverse -%>
+<% if @soaip -%>
 <%= @soa %>. IN A <%= @soaip %>
-<% end %>
+<% end -%>
+<% if @soaipv6 -%>
+<%= @soa %>. IN AAAA <%= @soaipv6 %>
+<% end -%>
+<% end -%>


### PR DESCRIPTION
This makes the $soaip parameter optional since in many cases it doesn't makes sense. It was also breaking hard on IPv6-only systems. For those setups the $soaipv6 parameter is also added. The types are also tightened to the correct address family.