### PR TITLE
Fixes #28939 - Replace DNS zone file

### DIFF
--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -97,7 +97,7 @@ define dns::zone (
       group   => $dns::group,
       mode    => '0644',
       content => template('dns/zone.header.erb'),
-      replace => false,
+      replace => true,
       notify  => Class['dns::service'],
     }
   }

--- a/spec/defines/dns_zone_spec.rb
+++ b/spec/defines/dns_zone_spec.rb
@@ -35,7 +35,7 @@ describe 'dns::zone' do
       :owner    => 'named',
       :group    => 'named',
       :mode     => '0644',
-      :replace  => 'false',
+      :replace  => 'true',
     }).that_notifies('Class[Dns::Service]')
   end
 


### PR DESCRIPTION
When running `satellite-change-hostname`, it was not updating DNS resource records when applicable.

For the DNS zone file, this update sets the `replace` value to `true` instead of false
* Replaces DNS zone files in `/var/named/dynamic` with the correct contents after hostname change
* Only replaces the file if its `md5sum` is different
* Will happen automatically since `satellite-change-hostname` runs `foreman-installer`.
