### PR TITLE
Make zone update_policy_rules more generic

### DIFF
--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -49,10 +49,22 @@ define dns::zone (
   Enum['first', 'only'] $forward                        = 'first',
   Array $forwarders                                     = [],
   Optional[Enum['yes', 'no', 'explicit']] $dns_notify   = undef,
-  Hash[String, Hash[String, Data]] $update_policy_rules = {},
+  Hash[String, Hash[String, Data]] $update_policy_rules = {}, # deprecated
+  Optional[Dns::UpdatePolicy] $update_policy            = undef,
 ) {
 
   $_contact = pick($contact, "root.${zone}.")
+
+  if $update_policy == undef {
+    if $update_policy_rules.length > 0 {
+      warning('update_policy_rules are deprecated in favour of update_policy')
+    }
+    $real_update_policy = $update_policy_rules + {
+      'rndc-key' => {'matchtype' => 'zonesub', 'rr' => 'ANY'}
+    }
+  } else {
+    $real_update_policy = $update_policy
+  }
 
   $zonefilename = "${zonefilepath}/${filename}"
 

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -24,47 +24,35 @@
 #   tname and rr are optional
 #
 define dns::zone (
-  Array[String] $target_views                           = [],
-  String $zonetype                                      = 'master',
-  String $soa                                           = $fqdn,
-  Boolean $reverse                                      = false,
-  String $ttl                                           = '10800',
-  Optional[Stdlib::IP::Address::V4] $soaip              = undef,
-  Optional[Stdlib::IP::Address::V6] $soaipv6            = undef,
-  Integer $refresh                                      = 86400,
-  Integer $update_retry                                 = 3600,
-  Integer $expire                                       = 604800,
-  Integer $negttl                                       = 3600,
-  Integer $serial                                       = 1,
-  Array $masters                                        = [],
-  Array $allow_transfer                                 = [],
-  Array $allow_query                                    = [],
-  Array $also_notify                                    = [],
-  String $zone                                          = $title,
-  Optional[String] $contact                             = undef,
-  Stdlib::Absolutepath $zonefilepath                    = $dns::zonefilepath,
-  String $filename                                      = "db.${title}",
-  Boolean $manage_file                                  = true,
-  Boolean $manage_file_name                             = false,
-  Enum['first', 'only'] $forward                        = 'first',
-  Array $forwarders                                     = [],
-  Optional[Enum['yes', 'no', 'explicit']] $dns_notify   = undef,
-  Hash[String, Hash[String, Data]] $update_policy_rules = {}, # deprecated
-  Optional[Dns::UpdatePolicy] $update_policy            = undef,
+  Array[String] $target_views                         = [],
+  String $zonetype                                    = 'master',
+  String $soa                                         = $fqdn,
+  Boolean $reverse                                    = false,
+  String $ttl                                         = '10800',
+  Optional[Stdlib::IP::Address::V4] $soaip            = undef,
+  Optional[Stdlib::IP::Address::V6] $soaipv6          = undef,
+  Integer $refresh                                    = 86400,
+  Integer $update_retry                               = 3600,
+  Integer $expire                                     = 604800,
+  Integer $negttl                                     = 3600,
+  Integer $serial                                     = 1,
+  Array $masters                                      = [],
+  Array $allow_transfer                               = [],
+  Array $allow_query                                  = [],
+  Array $also_notify                                  = [],
+  String $zone                                        = $title,
+  Optional[String] $contact                           = undef,
+  Stdlib::Absolutepath $zonefilepath                  = $dns::zonefilepath,
+  String $filename                                    = "db.${title}",
+  Boolean $manage_file                                = true,
+  Boolean $manage_file_name                           = false,
+  Enum['first', 'only'] $forward                      = 'first',
+  Array $forwarders                                   = [],
+  Optional[Enum['yes', 'no', 'explicit']] $dns_notify = undef,
+  Optional[Dns::UpdatePolicy] $update_policy          = undef,
 ) {
 
   $_contact = pick($contact, "root.${zone}.")
-
-  if $update_policy == undef {
-    if $update_policy_rules.length > 0 {
-      warning('update_policy_rules are deprecated in favour of update_policy')
-    }
-    $real_update_policy = $update_policy_rules + {
-      'rndc-key' => {'matchtype' => 'zonesub', 'rr' => 'ANY'}
-    }
-  } else {
-    $real_update_policy = $update_policy
-  }
 
   $zonefilename = "${zonefilepath}/${filename}"
 

--- a/spec/defines/dns_zone_spec.rb
+++ b/spec/defines/dns_zone_spec.rb
@@ -359,31 +359,6 @@ describe 'dns::zone' do
         end
       end
 
-      context 'deprecated update_policy_rules' do
-        let(:params) { {
-          :update_policy_rules => {
-            'foreman_key' => {
-              'action'    => 'grant',
-              'matchtype' => 'zonesub',
-              'rr'        => 'ANY'
-            },
-          }
-        } }
-
-        it "should have valid zone configuration" do
-          verify_concat_fragment_exact_contents(catalogue, 'dns_zones+10__GLOBAL__example.com.dns', [
-          'zone "example.com" {',
-          '    type master;',
-          "    file \"#{zonefilepath}/db.example.com\";",
-          '    update-policy {',
-          '            grant rndc-key zonesub ANY;',
-          '            grant foreman_key zonesub ANY;',
-          '    };',
-          '};',
-        ])
-        end
-      end
-
       context 'update_policy uses non-default key' do
         let(:params) { {
           :update_policy => {

--- a/spec/defines/dns_zone_spec.rb
+++ b/spec/defines/dns_zone_spec.rb
@@ -1,6 +1,16 @@
 require 'spec_helper'
 
 describe 'dns::zone' do
+
+  rndc_policy_params = {
+    :update_policy => {
+      'rndc-key' => {
+        'matchtype' => 'zonesub',
+        'rr'        => 'ANY'
+      },
+    },
+  }
+
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts.merge(fqdn: 'puppetmaster.example.com') }
@@ -35,9 +45,6 @@ describe 'dns::zone' do
           'zone "example.com" {',
           '    type master;',
           "    file \"#{zonefilepath}/db.example.com\";",
-          '    update-policy {',
-          '            grant rndc-key zonesub ANY;',
-          '    };',
           '};',
         ])
       end
@@ -105,7 +112,7 @@ describe 'dns::zone' do
       end
 
       context 'when allow_transfer defined' do
-        let(:params) {{ :allow_transfer => ['192.168.1.2'] }}
+        let(:params) {rndc_policy_params.merge({ :allow_transfer => ['192.168.1.2'] })}
 
         it "should have valid zone configuration with allow-transfer" do
           verify_concat_fragment_exact_contents(catalogue, 'dns_zones+10__GLOBAL__example.com.dns', [
@@ -121,7 +128,7 @@ describe 'dns::zone' do
         end
 
         context 'when allow_transfer with multiple values' do
-          let(:params) {{ :allow_transfer => ['192.168.1.2', '192.168.1.3'] }}
+          let(:params) {rndc_policy_params.merge({ :allow_transfer => ['192.168.1.2', '192.168.1.3'] })}
 
           it "should have valid zone configuration with allow-transfer" do
             verify_concat_fragment_exact_contents(catalogue, 'dns_zones+10__GLOBAL__example.com.dns', [
@@ -139,7 +146,7 @@ describe 'dns::zone' do
       end
 
       context 'when also_notify defined' do
-        let(:params) {{ :also_notify => ['192.168.1.2'] }}
+        let(:params) {rndc_policy_params.merge({ :also_notify => ['192.168.1.2'] })}
 
         it "should have valid zone configuration with also-notify" do
           verify_concat_fragment_exact_contents(catalogue, 'dns_zones+10__GLOBAL__example.com.dns', [
@@ -155,7 +162,7 @@ describe 'dns::zone' do
         end
 
         context 'when also_notify with multiple values' do
-          let(:params) {{ :also_notify => ['192.168.1.2', '192.168.1.3'] }}
+          let(:params) {rndc_policy_params.merge({ :also_notify => ['192.168.1.2', '192.168.1.3'] })}
 
           it "should have valid zone configuration with also-notify" do
             verify_concat_fragment_exact_contents(catalogue, 'dns_zones+10__GLOBAL__example.com.dns', [
@@ -202,7 +209,7 @@ describe 'dns::zone' do
         end
 
         context 'when dns_notify => no' do
-          let(:params) {{ :dns_notify => 'no' }}
+          let(:params) {rndc_policy_params.merge({ :dns_notify => 'no' })}
 
           it "should have valid slave zone configuration" do
             verify_concat_fragment_exact_contents(catalogue, 'dns_zones+10__GLOBAL__example.com.dns', [
@@ -266,9 +273,6 @@ describe 'dns::zone' do
               'zone "example.com" {',
               '    type master;',
               "    file \"#{zonefilepath}/db.example.com\";",
-              '    update-policy {',
-              '            grant rndc-key zonesub ANY;',
-              '    };',
               '};',
             ])
           end
@@ -278,9 +282,6 @@ describe 'dns::zone' do
               'zone "example.com" {',
               '    type master;',
               "    file \"#{zonefilepath}/db.example.com\";",
-              '    update-policy {',
-              '            grant rndc-key zonesub ANY;',
-              '    };',
               '};',
             ])
           end

--- a/spec/defines/dns_zone_spec.rb
+++ b/spec/defines/dns_zone_spec.rb
@@ -398,21 +398,6 @@ describe 'dns::zone' do
         ])
         end
       end
-
-      context 'update_policy set to none' do
-        let(:params) { {
-          :update_policy => 'none',
-        } }
-
-        it "should have valid zone configuration" do
-          verify_concat_fragment_exact_contents(catalogue, 'dns_zones+10__GLOBAL__example.com.dns', [
-          'zone "example.com" {',
-          '    type master;',
-          "    file \"#{zonefilepath}/db.example.com\";",
-          '};',
-        ])
-        end
-      end
     end
   end
 end

--- a/templates/named.zone.erb
+++ b/templates/named.zone.erb
@@ -11,10 +11,8 @@ zone "<%= @zone %>" {
 <% end -%>
 <% if @zonetype == 'master' -%>
 <%   if @update_policy.is_a? String -%>
-<%     if @update_policy != 'none' -%>
     update-policy <%= @update_policy %>;
-<%     end -%>
-<%   else -%>
+<%   elsif @update_policy -%>
     update-policy {
             <%- @update_policy.sort_by {|k, v| k}.each do |key, key_hash| -%>
             <%= key_hash['action'] || 'grant' %> <%= key %> <%= key_hash['matchtype'] %> <% if key_hash['tname'] %><%= key_hash['tname'] %> <% end %><%= key_hash['rr'] %>;

--- a/templates/named.zone.erb
+++ b/templates/named.zone.erb
@@ -10,13 +10,13 @@ zone "<%= @zone %>" {
     file "<%= @zonefilename %>";
 <% end -%>
 <% if @zonetype == 'master' -%>
-<%   if @real_update_policy.is_a? String -%>
-<%     if @real_update_policy != 'none' -%>
-    update-policy <%= @real_update_policy %>;
+<%   if @update_policy.is_a? String -%>
+<%     if @update_policy != 'none' -%>
+    update-policy <%= @update_policy %>;
 <%     end -%>
 <%   else -%>
     update-policy {
-            <%- @real_update_policy.sort_by {|k, v| k}.each do |key, key_hash| -%>
+            <%- @update_policy.sort_by {|k, v| k}.each do |key, key_hash| -%>
             <%= key_hash['action'] || 'grant' %> <%= key %> <%= key_hash['matchtype'] %> <% if key_hash['tname'] %><%= key_hash['tname'] %> <% end %><%= key_hash['rr'] %>;
             <%- end -%>
     };

--- a/templates/named.zone.erb
+++ b/templates/named.zone.erb
@@ -10,12 +10,17 @@ zone "<%= @zone %>" {
     file "<%= @zonefilename %>";
 <% end -%>
 <% if @zonetype == 'master' -%>
+<%   if @real_update_policy.is_a? String -%>
+<%     if @real_update_policy != 'none' -%>
+    update-policy <%= @real_update_policy %>;
+<%     end -%>
+<%   else -%>
     update-policy {
-            grant rndc-key zonesub ANY;
-            <%- @update_policy_rules.sort_by {|k, v| k}.each do |key, key_hash| -%>
-            grant <%= key %> <%= key_hash['matchtype'] %> <% if key_hash['tname'] %><%= key_hash['tname'] %> <% end %><% if key_hash['rr'] %><%= key_hash['rr'] %><% end %>;
+            <%- @real_update_policy.sort_by {|k, v| k}.each do |key, key_hash| -%>
+            <%= key_hash['action'] || 'grant' %> <%= key %> <%= key_hash['matchtype'] %> <% if key_hash['tname'] %><%= key_hash['tname'] %> <% end %><%= key_hash['rr'] %>;
             <%- end -%>
     };
+<%   end -%>
 <% end -%>
 <% unless @zonetype == 'forward' -%>
 <% unless @allow_transfer.empty? -%>

--- a/types/updatepolicy.pp
+++ b/types/updatepolicy.pp
@@ -1,0 +1,30 @@
+# Validate update-policy parameter
+type Dns::UpdatePolicy = Variant[
+  Enum['none', 'local'],
+  Hash[
+    String,
+    Struct[{
+      Optional[action] => Enum['deny', 'grant'],
+      Optional[tname]  => String,
+      rr               => String,
+      matchtype        => Enum[
+        '6to4-self',
+        'external',
+        'krb5-self',
+        'krb5-selfsub',
+        'krb5-subdomain',
+        'ms-self',
+        'ms-selfsub',
+        'ms-subdomain',
+        'name',
+        'self',
+        'selfsub',
+        'selfwild',
+        'subdomain',
+        'tcp-self',
+        'wildcard',
+        'zonesub',
+      ],
+    }],
+  ],
+]

--- a/types/updatepolicy.pp
+++ b/types/updatepolicy.pp
@@ -1,6 +1,6 @@
 # Validate update-policy parameter
 type Dns::UpdatePolicy = Variant[
-  Enum['none', 'local'],
+  Enum['local'],
   Hash[
     String,
     Struct[{


### PR DESCRIPTION
This is part of https://github.com/theforeman/puppet-dns/issues/156. I submit it separately from the other zone options I want to introduce, because this PR might be a breaking change for some installations.