### PR TITLE
Add the ability to define logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,47 @@ dns::key {'dns-key':}
 Slaves can also be configured by setting `allow_transfer` in the master's zone
 and setting `zonetype => 'slave'` in the slave's zone.
 
+Logging can be added with the `dns::logging_categories` and `dns::logging_channels` defined types.  The following Hiera example shows all the available options:
+
+```yaml
+dns::logging_categories:
+  unmatched:
+    channels:
+      - 'test_file'
+      - 'test_stderr'
+      - 'test_syslog'
+      - 'test_null'
+dns::logging_channels:
+  test_file:
+    file_path: '/var/log/named/test.log'
+    file_versions: 3
+    file_size: '5m'
+    log_type: 'file'
+    print_category: 'yes'
+    print_severity: 'yes'
+    print_time: 'yes'
+    severity: 'dynamic'
+  test_null:
+    log_type: 'null'
+    print_category: 'yes'
+    print_severity: 'yes'
+    print_time: 'yes'
+    severity: 'dynamic'
+  test_stderr:
+    log_type: 'stderr'
+    print_category: 'yes'
+    print_severity: 'yes'
+    print_time: 'yes'
+    severity: 'dynamic'
+  test_syslog:
+    log_type: 'syslog'
+    print_category: 'yes'
+    print_severity: 'yes'
+    print_time: 'yes'
+    severity: 'dynamic'
+    syslog_facility: 'auth'
+```
+
 # Credits
 
 Based on zleslie-dns, with a lot of the guts ripped out. Thanks
@@ -47,7 +88,7 @@ See the CONTRIBUTING.md file for much more information.
 
 # More info
 
-See https://theforeman.org or at #theforeman irc channel on freenode
+See [https://theforeman.org](https://theforeman.org) or at #theforeman irc channel on freenode
 
 Copyright (c) 2010-2016 Foreman developers and Zach Leslie
 
@@ -55,7 +96,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-https://www.apache.org/licenses/LICENSE-2.0
+[https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0)
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -24,7 +24,7 @@ class dns::config {
   }
 
   concat { $dns::namedconf_path:
-    owner        => root,
+    owner        => 'root',
     group        => $dns::params::group,
     mode         => '0640',
     require      => Concat[$dns::optionspath],
@@ -34,7 +34,7 @@ class dns::config {
   # This file cannot be checked by named-checkconf because its content is only
   # valid inside an "options { };" directive.
   concat { $dns::optionspath:
-    owner => root,
+    owner => 'root',
     group => $dns::params::group,
     mode  => '0640',
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,6 +14,8 @@
 #   Path of the config file holding all the zones
 # @param vardir
 #   Directory holding the variable or working files
+# @param logdir
+#   Directory holding the log files for named
 # @param group_manage
 #   Should this module manage the Unix system group under which BIND runs (see
 #   dns::params)?  Defaults to true. Set to false if you want to manage the
@@ -119,9 +121,15 @@
 #   A hash of zones to be created. See dns::zone for options.
 # @param keys
 #   A hash of keys to be created. See dns::key for options.
+# @param logging_categories
+#   A hash of logging categories to be created. See dns::logging::category for options.
+# @param logging_channels
+#   A hash of logging channels to be created. See dns::logging::channel for options.
 #
 # @see dns::zone
 # @see dns::key
+# @see dns::logging::category
+# @see dns::logging::channel
 class dns (
   Stdlib::Absolutepath $namedconf_path                              = $dns::params::namedconf_path,
   Stdlib::Absolutepath $dnsdir                                      = $dns::params::dnsdir,
@@ -130,6 +138,7 @@ class dns (
   Stdlib::Absolutepath $optionspath                                 = $dns::params::optionspath,
   Stdlib::Absolutepath $publicviewpath                              = $dns::params::publicviewpath,
   Stdlib::Absolutepath $vardir                                      = $dns::params::vardir,
+  Stdlib::Absolutepath $logdir                                      = $dns::params::logdir,
   Boolean $group_manage                                             = $dns::params::group_manage,
   Boolean $manage_service                                           = $dns::params::manage_service,
   String $namedservicename                                          = $dns::params::namedservicename,
@@ -164,6 +173,8 @@ class dns (
   Boolean $enable_views                                             = $dns::params::enable_views,
   Hash[String, Hash] $zones                                         = $dns::params::zones,
   Hash[String, Hash] $keys                                          = $dns::params::keys,
+  Hash[String, Hash] $logging_categories                            = $dns::params::logging_categories,
+  Hash[String, Hash] $logging_channels                              = $dns::params::logging_channels,
 ) inherits dns::params {
 
   include dns::install
@@ -174,4 +185,6 @@ class dns (
 
   create_resources('dns::key', $keys)
   create_resources('dns::zone', $zones)
+  create_resources('dns::logging::category', $logging_categories)
+  create_resources('dns::logging::channel', $logging_channels)
 }

--- a/manifests/logging.pp
+++ b/manifests/logging.pp
@@ -1,0 +1,22 @@
+# Enable logging for named
+# @api private
+class dns::logging {
+  file { $dns::logdir:
+    ensure => directory,
+    owner  => $dns::params::user,
+    group  => $dns::params::group,
+    mode   => '0755',
+  }
+
+  concat::fragment { 'named.conf+50-logging-header.dns':
+    target  => $dns::namedconf_path,
+    content => "logging {\n",
+    order   => 50,
+  }
+
+  concat::fragment { 'named.conf+60-logging-footer.dns':
+    target  => $dns::namedconf_path,
+    content => "};\n",
+    order   => 60,
+  }
+}

--- a/manifests/logging/category.pp
+++ b/manifests/logging/category.pp
@@ -1,0 +1,21 @@
+# Define new category for logging
+#
+# @param channels
+#   The array of channels to attach to the category
+#
+# @param order
+#   The order of the category in the configuration file
+define dns::logging::category (
+  Array $channels,
+  Integer[51, 59] $order = 55,
+) {
+  include dns::logging
+
+  $category_name = $title
+
+  concat::fragment { "named.conf-logging-category-${title}.dns":
+    target  => $dns::namedconf_path,
+    content => template('dns/log.category.conf.erb'),
+    order   => $order,
+  }
+}

--- a/manifests/logging/channel.pp
+++ b/manifests/logging/channel.pp
@@ -1,0 +1,71 @@
+# Define new channel for logging
+#
+# @param file_path
+#   The path to the log file
+#
+# @param file_size
+#   The maximum size the log file is allowed to reach
+#
+# @param file_versions
+#   The number of log files to keep when rotating
+#
+# @param log_type
+#   The destination type for the log (file, stderr, syslog, or "null")
+#
+# @param order
+#   The order of the channel in the configuration file
+#
+# @param print_category
+#   Decide whether to log the category in the log message
+#
+# @param print_severity
+#   Decide whether to log the severity in the log message
+#
+# @param print_time
+#   Decide whether to log the time in the log message
+#
+# @param severity
+#   The severity of messages to log
+#
+# @param syslog_facility
+#   The syslog facility to use when logging to a syslog log_type
+define dns::logging::channel (
+  Optional[Stdlib::Absolutepath] $file_path          = undef,
+  Optional[String] $file_size                        = undef,
+  Optional[Integer] $file_versions                   = undef,
+  Enum['file', 'null', 'stderr', 'syslog'] $log_type = undef,
+  Integer[51, 59] $order                             = 51,
+  Optional[Enum['no', 'yes']] $print_category        = undef,
+  Optional[Enum['no', 'yes']] $print_severity        = undef,
+  Optional[Enum['no', 'yes']] $print_time            = undef,
+  Optional[String] $severity                         = undef,
+  Optional[String] $syslog_facility                  = undef,
+) {
+  include dns::logging
+
+  $channel_name = $title
+
+  if $log_type == 'syslog' {
+    if empty($syslog_facility) {
+      fail('dns::logging::channel: "syslog_faility" needs to be set with log type syslog')
+    }
+  }
+
+  if $log_type == 'file' {
+    if empty($file_path) {
+      fail('dns::logging::channel: "file_path" needs to be set with log type file')
+    }
+    if empty($file_size) {
+      fail('dns::logging::channel: "file_size" needs to be set with log type file')
+    }
+    if empty($file_versions) {
+      fail('dns::logging::channel: "file_versions" needs to be set with log type file')
+    }
+  }
+
+  concat::fragment { "named.conf-logging-channel-${title}.dns":
+    target  => $dns::namedconf_path,
+    content => template('dns/log.channel.conf.erb'),
+    order   => $order,
+  }
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -112,6 +112,8 @@ class dns::params {
 
   $namedconf_path        = "${dnsdir}/named.conf"
 
+  $logdir                = '/var/log/named'
+
   #pertaining to rndc
   $rndckeypath           = "${dnsdir}/rndc.key"
 
@@ -151,4 +153,6 @@ class dns::params {
 
   $zones                 = {}
   $keys                  = {}
+  $logging_categories    = {}
+  $logging_channels      = {}
 }

--- a/spec/acceptance/logging_spec.rb
+++ b/spec/acceptance/logging_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper_acceptance'
+
+describe 'Scenario: install bind with logging enabled' do
+  context 'with logging enabled' do
+    let(:pp) do
+      <<-EOS
+      class { 'dns':
+        logging_categories => {
+          queries => {
+            channels => ['queries_file'],
+          },
+        },
+        logging_channels   => {
+          queries_file => {
+            file_path     => '/var/log/named/queries.log',
+            file_versions => 6,
+            file_size     => '50m',
+            log_type      => 'file',
+            severity      => 'dynamic',
+            print_time    => 'yes',
+          },
+        },
+      }
+
+      dns::zone { 'example.com':
+        soa                => 'ns1.example.com',
+        soaip              => '192.0.2.1',
+        soaipv6            => '2001:db8::1',
+      }
+      EOS
+    end
+
+    it_behaves_like 'a idempotent resource'
+
+    service_name = fact('osfamily') == 'Debian' ? 'bind9' : 'named'
+
+    describe service(service_name) do
+      it { is_expected.to be_enabled }
+      it { is_expected.to be_running }
+    end
+
+    describe port(53) do
+      it { is_expected.to be_listening }
+    end
+
+    describe command('dig +short SOA example.com @localhost') do
+      its(:stdout) { is_expected.to match("ns1.example.com. root.example.com. 1 86400 3600 604800 3600\n") }
+    end
+
+    describe file('/var/log/named/queries.log') do
+      its(:content) { is_expected.to match(%r{query: example\.com IN SOA \+}) }
+    end
+  end
+end

--- a/spec/classes/dns_init_spec.rb
+++ b/spec/classes/dns_init_spec.rb
@@ -132,7 +132,7 @@ describe 'dns' do
             '};',
             "include \"#{localzonepath}\";",
             '// Public view read by Server Admin',
-            "include \"#{etc_named_directory}/zones.conf\";"
+            "include \"#{etc_named_directory}/zones.conf\";",
           ]
 
           unless localzonepath
@@ -151,6 +151,8 @@ describe 'dns' do
         it { should contain_file(rndc_key) }
 
         it { should contain_service(service_name).with_ensure('running').with_enable(true).with_restart(nil) }
+        it { is_expected.not_to contain_concat_fragment('named.conf+50-logging-header.dns') }
+        it { is_expected.not_to contain_concat_fragment('named.conf+60-logging-footer.dns') }
       end
 
       describe 'with unmanaged localzonepath' do
@@ -169,7 +171,7 @@ describe 'dns' do
           "        include \"#{options_path}\";",
           '};',
           '// Public view read by Server Admin',
-          "include \"#{etc_named_directory}/zones.conf\";"
+          "include \"#{etc_named_directory}/zones.conf\";",
         ])}
       end
 
@@ -222,7 +224,7 @@ describe 'dns' do
             '  ndots integer;',
             '};',
             '// Public view read by Server Admin',
-            "include \"#{etc_named_directory}/zones.conf\";"
+            "include \"#{etc_named_directory}/zones.conf\";",
           ].compact
 
           verify_concat_fragment_exact_contents(catalogue, 'named.conf+10-main.dns', expected)

--- a/spec/defines/dns_logging_category_spec.rb
+++ b/spec/defines/dns_logging_category_spec.rb
@@ -1,0 +1,89 @@
+require 'spec_helper'
+
+describe 'dns::logging::category' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts.merge(fqdn: 'puppetmaster.example.com') }
+      let(:pre_condition) { 'include dns' }
+      let(:title) { 'test' }
+      let(:logdir) { '/var/log/named' }
+
+      describe 'without channels set' do
+        it { is_expected.not_to compile }
+      end
+
+      describe 'with channels set' do
+        let(:params) { { 'channels' => ['test_channel'] } }
+
+        it { is_expected.to compile.with_all_deps }
+
+        it 'should have valid category contents' do
+          verify_concat_fragment_exact_contents(
+            catalogue,
+            "named.conf-logging-category-#{title}.dns",
+            [
+              '  category test {',
+              '    test_channel;',
+              '  };',
+            ]
+          )
+        end
+
+        it {
+          is_expected.to contain_concat_fragment(
+            "named.conf-logging-category-#{title}.dns"
+          ).with('order' => 55)
+        }
+
+        it { is_expected.to contain_file(logdir).with_ensure('directory') }
+        it {
+          is_expected.to contain_concat_fragment(
+            'named.conf+50-logging-header.dns'
+          ).with('order' => 50).with('content' => "logging {\n")
+        }
+        it {
+          is_expected.to contain_concat_fragment(
+            'named.conf+60-logging-footer.dns'
+          ).with('order' => 60).with('content' => "};\n")
+        }
+      end
+
+      describe 'when order => 59' do
+        let(:params) do
+          {
+            'channels' => ['test_channel'],
+            'order'    => 59,
+          }
+        end
+
+        it {
+          is_expected.to contain_concat_fragment(
+            "named.conf-logging-category-#{title}.dns"
+          ).with('order' => 59)
+        }
+      end
+
+      describe 'fail when order => 50' do
+        let(:params) do
+          {
+            'channels' => ['test_channel'],
+            'order'    => 50,
+          }
+        end
+
+        it { is_expected.not_to compile }
+      end
+
+      describe 'fail when order => 60' do
+        let(:params) do
+          {
+            'channels' => ['test_channel'],
+            'order'    => 60,
+          }
+        end
+
+        it { is_expected.not_to compile }
+      end
+    end
+  end
+end

--- a/spec/defines/dns_logging_channel_spec.rb
+++ b/spec/defines/dns_logging_channel_spec.rb
@@ -1,0 +1,303 @@
+require 'spec_helper'
+
+describe 'dns::logging::channel' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts.merge(fqdn: 'puppetmaster.example.com') }
+      let(:pre_condition) { 'include dns' }
+      let(:title) { 'test' }
+      let(:logdir) { '/var/log/named' }
+
+      describe 'without log_type set' do
+        it { is_expected.not_to compile }
+      end
+
+      describe 'with log_type = null set' do
+        let(:params) { { 'log_type' => 'null' } }
+
+        it { is_expected.to compile.with_all_deps }
+
+        it 'should have valid channel contents' do
+          verify_concat_fragment_exact_contents(
+            catalogue,
+            "named.conf-logging-channel-#{title}.dns",
+            [
+              '  channel test {',
+              '    null;',
+              '  };',
+            ]
+          )
+        end
+
+        it {
+          is_expected.to contain_concat_fragment(
+            "named.conf-logging-channel-#{title}.dns"
+          ).with('order' => 51)
+        }
+
+        it { should contain_file(logdir).with_ensure('directory') }
+        it {
+          is_expected.to contain_concat_fragment(
+            'named.conf+50-logging-header.dns'
+          ).with('order' => 50).with('content' => "logging {\n")
+        }
+        it {
+          is_expected.to contain_concat_fragment(
+            'named.conf+60-logging-footer.dns'
+          ).with('order' => 60).with('content' => "};\n")
+        }
+      end
+
+      describe 'with log_type = null set and order = 55' do
+        let(:params) do
+          {
+            'log_type' => 'null',
+            'order'    => 55,
+          }
+        end
+
+        it {
+          is_expected.to contain_concat_fragment(
+            "named.conf-logging-channel-#{title}.dns"
+          ).with('order' => 55)
+        }
+      end
+
+      describe 'with log_type = stderr set' do
+        let(:params) { { 'log_type' => 'stderr' } }
+
+        it 'should have valid channel contents' do
+          verify_concat_fragment_exact_contents(
+            catalogue,
+            "named.conf-logging-channel-#{title}.dns",
+            [
+              '  channel test {',
+              '    stderr;',
+              '  };',
+            ]
+          )
+        end
+
+        it {
+          is_expected.to contain_concat_fragment(
+            "named.conf-logging-channel-#{title}.dns"
+          ).with('order' => 51)
+        }
+      end
+
+      describe 'with log_type = syslog and syslog_facility not set' do
+        let(:params) { { 'log_type' => 'syslog' } }
+
+        it { is_expected.not_to compile }
+      end
+
+      describe 'with log_type = syslog and syslog_facility set' do
+        let(:params) do
+          {
+            'log_type'        => 'syslog',
+            'syslog_facility' => 'auth',
+          }
+        end
+
+        it 'should have valid channel contents' do
+          verify_concat_fragment_exact_contents(
+            catalogue,
+            "named.conf-logging-channel-#{title}.dns",
+            [
+              '  channel test {',
+              '    syslog auth;',
+              '  };',
+            ]
+          )
+        end
+      end
+
+      describe 'with log_type = file and other options not set' do
+        let(:params) { { 'log_type' => 'file' } }
+
+        it { is_expected.not_to compile }
+      end
+
+      describe 'with log_type = file and file_path not set' do
+        let(:params) do
+          {
+            'log_type'      => 'file',
+            'file_size'     => '5m',
+            'file_versions' => 3,
+          }
+        end
+
+        it { is_expected.not_to compile }
+      end
+
+      describe 'with log_type = file and file_size not set' do
+        let(:params) do
+          {
+            'log_type'      => 'file',
+            'file_path'     => '/path/to/file.log',
+            'file_versions' => 3,
+          }
+        end
+
+        it { is_expected.not_to compile }
+      end
+
+      describe 'with log_type = file and file_size not an integer set' do
+        let(:params) do
+          {
+            'log_type'      => 'file',
+            'file_path'     => '/path/to/file.log',
+            'file_versions' => '3',
+          }
+        end
+
+        it { is_expected.not_to compile }
+      end
+
+      describe 'with log_type = file and file_versions not set' do
+        let(:params) do
+          {
+            'log_type'  => 'file',
+            'file_path' => '/path/to/file.log',
+            'file_size' => '5m',
+          }
+        end
+
+        it { is_expected.not_to compile }
+      end
+
+      describe 'with log_type = syslog and all options set' do
+        let(:params) do
+          {
+            'log_type'      => 'file',
+            'file_path'     => '/path/to/file.log',
+            'file_size'     => '5m',
+            'file_versions' => 4,
+          }
+        end
+
+        it 'should have valid channel contents' do
+          verify_concat_fragment_exact_contents(
+            catalogue,
+            "named.conf-logging-channel-#{title}.dns",
+            [
+              '  channel test {',
+              '    file "/path/to/file.log" versions 4 size 5m;',
+              '  };',
+            ]
+          )
+        end
+      end
+
+      describe 'with severity set' do
+        let(:params) do
+          {
+            'log_type' => 'stderr',
+            'severity' => 'dynamic',
+          }
+        end
+
+        it 'should have valid channel contents' do
+          verify_concat_fragment_exact_contents(
+            catalogue,
+            "named.conf-logging-channel-#{title}.dns",
+            [
+              '  channel test {',
+              '    stderr;',
+              '    severity dynamic;',
+              '  };',
+            ]
+          )
+        end
+      end
+
+      describe 'with print_category set' do
+        let(:params) do
+          {
+            'log_type'       => 'stderr',
+            'print_category' => 'yes',
+          }
+        end
+
+        it 'should have valid channel contents' do
+          verify_concat_fragment_exact_contents(
+            catalogue,
+            "named.conf-logging-channel-#{title}.dns",
+            [
+              '  channel test {',
+              '    stderr;',
+              '    print-category yes;',
+              '  };',
+            ]
+          )
+        end
+      end
+
+      describe 'with print_severity set' do
+        let(:params) do
+          {
+            'log_type'       => 'stderr',
+            'print_severity' => 'yes',
+          }
+        end
+
+        it 'should have valid channel contents' do
+          verify_concat_fragment_exact_contents(
+            catalogue,
+            "named.conf-logging-channel-#{title}.dns",
+            [
+              '  channel test {',
+              '    stderr;',
+              '    print-severity yes;',
+              '  };',
+            ]
+          )
+        end
+      end
+
+      describe 'with print_time set' do
+        let(:params) do
+          {
+            'log_type'   => 'stderr',
+            'print_time' => 'yes',
+          }
+        end
+
+        it 'should have valid channel contents' do
+          verify_concat_fragment_exact_contents(
+            catalogue,
+            "named.conf-logging-channel-#{title}.dns",
+            [
+              '  channel test {',
+              '    stderr;',
+              '    print-time yes;',
+              '  };',
+            ]
+          )
+        end
+      end
+
+      describe 'fail when order => 50' do
+        let(:params) do
+          {
+            'log_type' => 'stderr',
+            'order'    => 50,
+          }
+        end
+
+        it { is_expected.to compile.and_raise_error(%r{order}) }
+      end
+
+      describe 'fail when order => 60' do
+        let(:params) do
+          {
+            'log_type' => 'stderr',
+            'order'    => 60,
+          }
+        end
+
+        it { is_expected.to compile.and_raise_error(%r{order}) }
+      end
+    end
+  end
+end

--- a/templates/log.category.conf.erb
+++ b/templates/log.category.conf.erb
@@ -1,0 +1,5 @@
+  category <%= @category_name %> {
+    <%- @channels.sort.each do |channel_name| -%>
+    <%= channel_name %>;
+    <%- end -%>
+  };

--- a/templates/log.channel.conf.erb
+++ b/templates/log.channel.conf.erb
@@ -1,0 +1,23 @@
+  channel <%= @channel_name %> {
+    <%- if @log_type == 'file' -%>
+    file "<%= @file_path -%>" versions <%= @file_versions -%> size <%= @file_size -%>;
+    <%- elsif @log_type == 'null' -%>
+    null;
+    <%- elsif @log_type == 'stderr' -%>
+    stderr;
+    <%- elsif @log_type == 'syslog' -%>
+    syslog <%= @syslog_facility -%>;
+    <%- end -%>
+    <%- if @severity and ! @severity.empty? -%>
+    severity <%= @severity -%>;
+    <%- end -%>
+    <%- if @print_category and ! @print_category.empty? -%>
+    print-category <%= @print_category -%>;
+    <%- end -%>
+    <%- if @print_severity and ! @print_severity.empty? -%>
+    print-severity <%= @print_severity -%>;
+    <%- end -%>
+    <%- if @print_time and ! @print_time.empty? -%>
+    print-time <%= @print_time -%>;
+    <%- end -%>
+  };


### PR DESCRIPTION
There was no way in the current settings to configure a log directory or an advanced logging configuration using channels and categories.  This change adds the necessary configuration options and template changes to create a full-featured logging configuration.  README and spec changes have been completed to document and test the change.