### PR TITLE
Fix custom key ordering

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,10 +1,6 @@
 # Configure dns
 # @api private
 class dns::config {
-  if $dns::group_manage {
-    group { $dns::params::group: }
-  }
-
   concat { $dns::publicviewpath:
     owner        => root,
     group        => $dns::params::group,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,5 +3,14 @@
 class dns::install {
   if ! empty($dns::dns_server_package) {
     ensure_packages([$dns::dns_server_package])
+    $pkg_req = Package[$dns::dns_server_package]
+  } else {
+    $pkg_req = undef
+  }
+
+  if $dns::group_manage {
+    group { $dns::group:
+      require => $pkg_req,
+    }
   }
 }

--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -33,12 +33,14 @@ define dns::key(
       group   => $dns::group,
       mode    => '0640',
       content => template('dns/key.erb'),
+      before  => Class['dns::config'],
       notify  => Class['dns::service'],
     }
   } else {
     exec { "create-${filename}":
       command => "${dns::rndcconfgen} -r /dev/urandom -a -c ${keyfilename} -b ${keysize} -k ${name}",
       creates => $keyfilename,
+      before  => Class['dns::config'],
       notify  => Class['dns::service'],
     }-> file { $keyfilename:
       owner => 'root',


### PR DESCRIPTION
When defining a custom key, the configuration validation would fail on the first run as the configuration would be updated and the validation would run before the key was created.  The error would go away on the second run as the file would then exist before the configuration was updated (from the previous run).  The updated ordering in `dns::key` makes this now work on the first run without an error.

As a note, the `group` creation needed to be moved out of `dns::config` to prevent a dependency cycle.