### PR TITLE
Update zone documentation

### DIFF
--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -16,7 +16,7 @@
 # @param manage_file_name
 #   Whether to set the file parameter in the zone file.
 #
-# @param update_policy_rules
+# @param update_policy
 #   This can be used to specifiy additional update policy rules in the
 #   following format
 #   { '<KEY_NAME' => {'matchtype' => '<VALUE>', 'tname' => '<VALUE>', 'rr' => 'VALUE' } }

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -23,6 +23,32 @@
 #   Example {'foreman_key' => {'matchtype' => 'zonesub', 'rr' => 'ANY'}}
 #   tname and rr are optional
 #
+# @param target_views
+# @param zonetype
+# @param soa
+# @param reverse
+# @param ttl
+# @param refresh
+# @param update_retry
+# @param expire
+# @param negttl
+# @param serial
+# @param masters
+# @param allow_transfer
+# @param allow_query
+# @param also_notify
+# @param zone
+# @param contact
+# @param zonefilepath
+# @param filename
+# @param forward
+# @param forwarders
+# @param dns_notify
+# @param key_directory
+# @param inline_signing
+# @param dnssec_secure_to_insecure
+# @param auto_dnssec
+#
 define dns::zone (
   Array[String] $target_views                             = [],
   String $zonetype                                        = 'master',


### PR DESCRIPTION
`update_policy_rules` was removed some time ago but I still found a reference to its usage in the zone.pp puppet-strings documentation.

This PR updates the docs parameter as well as adding all the other missing ones (even though it doesn't define them, it's better than nothing ;-) ).

Thanks to [Erasys GmbH](https://erasys.de) for their support