### PR TITLE
Replace get_in_addr_arpa with reverse_dns function

### DIFF
--- a/lib/puppet/functions/dns/reverse_dns.rb
+++ b/lib/puppet/functions/dns/reverse_dns.rb
@@ -1,0 +1,15 @@
+require 'ipaddr'
+
+# @summary Get the reverse DNS for an IP address
+Puppet::Functions.create_function(:'dns::reverse_dns') do
+  # @param ip
+  #   The IP address to get the reverse for
+  dispatch :reverse do
+    param 'Stdlib::IP::Address::Nosubnet', :ip
+    return_type 'Stdlib::Fqdn'
+  end
+
+  def reverse(ip)
+    IPAddr.new(ip).reverse
+  end
+end

--- a/lib/puppet/functions/get_in_addr_arpa.rb
+++ b/lib/puppet/functions/get_in_addr_arpa.rb
@@ -1,0 +1,10 @@
+# @summary DEPRECATED.  Use the [`dns::reverse_dns`](#dnsreverse_dns) function instead.
+Puppet::Functions.create_function(:get_in_addr_arpa) do
+  dispatch :deprecation_gen do
+    repeated_param 'Any', :args
+  end
+  def deprecation_gen(*args)
+    call_function('deprecation', 'get_in_addr_arpa', 'This method is deprecated, please use dns::reverse_dns instead.')
+    call_function('dns::reverse_dns', *args)
+  end
+end

--- a/lib/puppet/parser/functions/get_in_addr_arpa.rb
+++ b/lib/puppet/parser/functions/get_in_addr_arpa.rb
@@ -1,5 +1,0 @@
-module Puppet::Parser::Functions
-  newfunction(:get_in_addr_arpa, :type => :rvalue) do |args|
-    "#{args[0].split(".").reverse.join(".")}.in-addr.arpa"
-  end
-end

--- a/spec/functions/reverse_dns_spec.rb
+++ b/spec/functions/reverse_dns_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe 'dns::reverse_dns' do
+  it { is_expected.to run.with_params('192.0.2.100').and_return('100.2.0.192.in-addr.arpa') }
+  it { is_expected.to run.with_params('2001:db8::').and_return('0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa') }
+  it { is_expected.to run.with_params('2001:db8').and_raise_error(ArgumentError, /parameter 'ip' expects a Stdlib::IP::Address::Nosubnet/) }
+end


### PR DESCRIPTION
The get_in_addr_arpa function did not support IPv6. Its implementation was also the old legacy function API. This replacement also has tests, data types and documentation.