### PR TITLE
Allow configuration checks to be turned off

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,11 +1,17 @@
 # Configure dns
 # @api private
 class dns::config {
+  if $dns::config_check {
+    $validate_cmd = "${dns::named_checkconf} %"
+  } else {
+    $validate_cmd = undef
+  }
+
   concat { $dns::publicviewpath:
     owner        => root,
     group        => $dns::params::group,
     mode         => '0640',
-    validate_cmd => "${dns::named_checkconf} %",
+    validate_cmd => $validate_cmd,
   }
 
   if $dns::enable_views {
@@ -28,7 +34,7 @@ class dns::config {
     group        => $dns::params::group,
     mode         => '0640',
     require      => Concat[$dns::optionspath],
-    validate_cmd => "${dns::named_checkconf} %",
+    validate_cmd => $validate_cmd,
   }
 
   # This file cannot be checked by named-checkconf because its content is only

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -109,6 +109,10 @@
 #   setting `service_restart_command` to `/usr/sbin/service bind9 reload` or
 #   `/usr/sbin/rndc reload` or even `/usr/bin/systemctl try-reload-or-restart bind9`.
 #   Default is 'undef' so the service resource default is used.
+# @param config_check
+#   Should this module run configuration checks before putting new configurations in
+#   place?  Defaults to true. Set to false if you don't want configuration checks when
+#   config files are changed.
 # @param additional_options
 #   Additional options
 # @param additional_directives
@@ -168,6 +172,7 @@ class dns (
   Variant[Enum['running', 'stopped'], Boolean] $service_ensure      = $dns::params::service_ensure,
   Boolean $service_enable                                           = $dns::params::service_enable,
   Optional[String[1]] $service_restart_command                      = $dns::params::service_restart_command,
+  Boolean $config_check                                             = $dns::params::config_check,
   Hash[String, Data] $additional_options                            = $dns::params::additional_options,
   Array[String] $additional_directives                              = $dns::params::additional_directives,
   Boolean $enable_views                                             = $dns::params::enable_views,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -146,6 +146,7 @@ class dns::params {
   $manage_service        = true
   $service_ensure        = 'running'
   $service_enable        = true
+  $config_check          = true
   $acls                  = {}
 
   $additional_options    = {}

--- a/spec/classes/dns_init_spec.rb
+++ b/spec/classes/dns_init_spec.rb
@@ -365,6 +365,17 @@ describe 'dns' do
         it { should contain_file("#{etc_directory}/dns-key.key") }
       end
 
+      describe 'with config_check set to false' do
+        let(:params) { { :config_check => false } }
+
+        it { is_expected.to compile.with_all_deps }
+
+        it {
+          is_expected.to contain_concat("#{etc_directory}/named.conf")
+            .without_validate_cmd()
+        }
+      end
+
       context 'sysconfig', if: ['Debian', 'RedHat'].include?(os_facts[:os]['family']) do
         let(:sysconfig_named_path) do
           case facts[:os]['family']


### PR DESCRIPTION
I was having the same issue as described in #164 so I added this so the checks could be turned off if needed.