### PR TITLE
Drop usage of -r from rndc-confgen

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -65,7 +65,7 @@ class dns::config {
   }
 
   exec { 'create-rndc.key':
-    command => "${dns::rndcconfgen} -r /dev/urandom -a -c ${dns::rndckeypath}",
+    command => "${dns::rndcconfgen} -a -c ${dns::rndckeypath}",
     creates => $dns::rndckeypath,
   }
   -> file { $dns::rndckeypath:

--- a/manifests/key.pp
+++ b/manifests/key.pp
@@ -38,7 +38,7 @@ define dns::key(
     }
   } else {
     exec { "create-${filename}":
-      command => "${dns::rndcconfgen} -r /dev/urandom -a -c ${keyfilename} -b ${keysize} -k ${name}",
+      command => "${dns::rndcconfgen} -a -c ${keyfilename} -b ${keysize} -k ${name}",
       creates => $keyfilename,
       before  => Class['dns::config'],
       notify  => Class['dns::service'],

--- a/spec/classes/dns_init_spec.rb
+++ b/spec/classes/dns_init_spec.rb
@@ -145,7 +145,7 @@ describe 'dns' do
         it { should contain_file(zonefilepath).with_ensure('directory') }
         it do
           should contain_exec('create-rndc.key')
-            .with_command("#{sbin}/rndc-confgen -r /dev/urandom -a -c #{rndc_key}")
+            .with_command("#{sbin}/rndc-confgen -a -c #{rndc_key}")
             .with_creates(rndc_key)
         end
         it { should contain_file(rndc_key) }


### PR DESCRIPTION
With bind-9.13.0+[1], -r option is deprecated and raises
error if passed. With earlier versions of bind also -r
option is optional and in it's absense there are default
function which provides random bytes. So let's drop the
-r option.

Fixes GH-189

[1] https://github.com/isc-projects/bind9/commit/3a4f820