### PR TITLE
Handle dnssec-enable config option removal

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,7 +56,8 @@
 # @param dns_notify
 #   The notify option in named.conf
 # @param dnssec_enable
-#   The dnssec-enable option
+#   The dnssec-enable option. This option is deprecated and has no effect since
+#   BIND 9.15. It's been removed in BIND 9.18.
 # @param dnssec_validation
 #   The dnssec-validation option
 # @param namedconf_template
@@ -157,7 +158,7 @@ class dns (
   Array[String] $allow_query                                        = ['any'],
   Enum['yes', 'no'] $empty_zones_enable                             = 'yes',
   Optional[Enum['yes', 'no', 'explicit']] $dns_notify               = undef,
-  Enum['yes', 'no'] $dnssec_enable                                  = 'yes',
+  Optional[Enum['yes', 'no']] $dnssec_enable                        = $dns::params::dnssec_enable,
   Enum['yes', 'no', 'auto'] $dnssec_validation                      = 'yes',
   String $namedconf_template                                        = 'dns/named.conf.erb',
   Hash[String, Array[String]] $acls                                 = {},

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,6 +24,12 @@ class dns::params {
 
       # This option is not relevant for Debian
       $sysconfig_disable_zone_checking = undef
+
+      $dnssec_enable = $facts['os']['name'] ? {
+        'Debian' => if versioncmp($facts['os']['release']['major'], '11') >= 0 { undef } else { 'yes' },
+        'Ubuntu' => if versioncmp($facts['os']['release']['major'], '20.04') >= 0 { undef } else { 'yes' },
+        default  => undef,
+      }
     }
     'RedHat': {
       $dnsdir             = '/etc'
@@ -47,6 +53,8 @@ class dns::params {
 
       # This option is not relevant for RedHat
       $sysconfig_resolvconf_integration = undef
+
+      $dnssec_enable = 'yes'
     }
     /^(FreeBSD|DragonFly)$/: {
       $dnsdir             = '/usr/local/etc/namedb'
@@ -69,6 +77,7 @@ class dns::params {
       $sysconfig_startup_options = undef
       $sysconfig_disable_zone_checking = undef
       $sysconfig_resolvconf_integration = undef
+      $dnssec_enable = undef
     }
     'Archlinux': {
       $dnsdir             = '/etc'
@@ -91,6 +100,8 @@ class dns::params {
       $sysconfig_startup_options = undef
       $sysconfig_disable_zone_checking = undef
       $sysconfig_resolvconf_integration = undef
+
+      $dnssec_enable = undef
     }
     default: {
       fail ("Unsupported operating system family ${facts['os']['family']}")

--- a/spec/classes/dns_init_spec.rb
+++ b/spec/classes/dns_init_spec.rb
@@ -100,16 +100,25 @@ describe 'dns' do
 
         it { should contain_concat(options_path) }
         it do
+          has_dnssec_enable = case facts[:os]['family']
+                              when 'Debian'
+                                ['9', '10', '18.04'].include?(facts[:os]['release']['major'])
+                              when 'RedHat'
+                                true
+                              else
+                                false
+                              end
           expected = [
             "directory \"#{var_path}\";",
             'recursion yes;',
             'allow-query { any; };',
-            'dnssec-enable yes;',
             'dnssec-validation yes;',
             'empty-zones-enable yes;',
             'listen-on-v6 { any; };',
             'allow-recursion { localnets; localhost; };'
           ]
+
+          expected << 'dnssec-enable yes;' if has_dnssec_enable
 
           if facts[:os]['family'] == 'FreeBSD'
             expected << 'pid-file "/var/run/named/pid";'

--- a/templates/options.conf.erb
+++ b/templates/options.conf.erb
@@ -8,7 +8,9 @@ forward <%= scope.lookupvar('::dns::forward') %>;
 
 recursion <%= scope.lookupvar('::dns::recursion') %>;
 allow-query { <%= scope.lookupvar('::dns::allow_query').join("; ") %>; };
+<% unless [false, nil, :undefined, :undef, ''].include?(scope.lookupvar('::dns::dnssec_enable')) -%>
 dnssec-enable <%= scope.lookupvar('::dns::dnssec_enable') %>;
+<% end -%>
 dnssec-validation <%= scope.lookupvar('::dns::dnssec_validation') %>;
 
 empty-zones-enable <%= scope.lookupvar('::dns::empty_zones_enable') %>;


### PR DESCRIPTION
In BIND 9.15 the dnssec-enable config option was made obsolete (it's always enabled) and 9.18 removed it.

Fixes #207