### PR TITLE
Manage zone records

### DIFF
--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -37,6 +37,10 @@
 # @param negttl
 # @param serial
 # @param records
+#   A list of records which will be added to the zone file in
+#   the RFC 1035 format (see https://datatracker.ietf.org/doc/html/rfc1035)
+#   Example ['host1 IN A 192.168.0.10', 'alt-host1 IN CNAME host1']
+#
 # @param masters
 # @param allow_transfer
 # @param allow_query

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -16,6 +16,9 @@
 # @param manage_file_name
 #   Whether to set the file parameter in the zone file.
 #
+# @param replace_file
+#   Whether to update the zone file when a change is detected.
+#
 # @param update_policy
 #   This can be used to specifiy additional update policy rules in the
 #   following format
@@ -33,6 +36,7 @@
 # @param expire
 # @param negttl
 # @param serial
+# @param records
 # @param masters
 # @param allow_transfer
 # @param allow_query
@@ -75,6 +79,7 @@ define dns::zone (
   String $filename                                        = "db.${title}",
   Boolean $manage_file                                    = true,
   Boolean $manage_file_name                               = false,
+  Boolean $replace_file                                   = false,
   Enum['first', 'only'] $forward                          = 'first',
   Array $forwarders                                       = [],
   Optional[Enum['yes', 'no', 'explicit']] $dns_notify     = undef,
@@ -131,7 +136,7 @@ define dns::zone (
       group   => $dns::group,
       mode    => '0644',
       content => template('dns/zone.header.erb'),
-      replace => false,
+      replace => $replace_file,
       notify  => Class['dns::service'],
     }
   }

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -68,7 +68,7 @@ define dns::zone (
   Integer $expire                                         = 604800,
   Integer $negttl                                         = 3600,
   Integer $serial                                         = 1,
-  Array $records                                          = [],
+  Array[String[1]] $records                               = [],
   Array $masters                                          = [],
   Array $allow_transfer                                   = [],
   Array $allow_query                                      = [],

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -64,6 +64,7 @@ define dns::zone (
   Integer $expire                                         = 604800,
   Integer $negttl                                         = 3600,
   Integer $serial                                         = 1,
+  Array $records                                          = [],
   Array $masters                                          = [],
   Array $allow_transfer                                   = [],
   Array $allow_query                                      = [],

--- a/templates/zone.header.erb
+++ b/templates/zone.header.erb
@@ -16,3 +16,6 @@ $TTL <%= @ttl %>
 <%= @soa %>. IN AAAA <%= @soaipv6 %>
 <% end -%>
 <% end -%>
+<%- @records.each do |record| -%>
+<%= record %>
+<%- end -%>


### PR DESCRIPTION
See #196 

@ekohl Is it OK for you to manage zone without validation or would you prefer a more specific type (which would lead to a configuration more difficult to maintain) ?

Example :
- I created something like this (in Hiera)
```
dns::zones:
  example.com:
    replace_file: true
    serial: 2
    records:
      - host1 IN A 192.168.0.1
      - host2 IN A 192.168.0.2
```
- Or you want something like this (don't mind the naming, just for the format)
```
dns::zones:
  example.com:
    replace_file: true
    serial: 2
    records:
      - name: host1
         xx: IN
         type: A
         dst: 192.168.0.1
...
```