### PR TITLE
Remove dnssec-enable option for EL >= 9

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -54,8 +54,7 @@ class dns::params {
       # This option is not relevant for RedHat
       $sysconfig_resolvconf_integration = undef
 
-      $dnssec_enable = $facts['os']['Family'] ? {
-        'RedHat' => if versioncmp($facts['os']['release']['major'], '8') >= 0 { undef } else { 'yes' },
+      $dnssec_enable = if versioncmp($facts['os']['release']['major'], '9') >= 0 { undef } else { 'yes' },
         default  => undef,
       }
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -54,7 +54,7 @@ class dns::params {
       # This option is not relevant for RedHat
       $sysconfig_resolvconf_integration = undef
 
-      $dnssec_enable = if versioncmp($facts['os']['release']['major'], '9') >= 0 { undef } else { 'yes' },
+      $dnssec_enable = if versioncmp($facts['os']['release']['major'], '9') >= 0 { undef } else { 'yes' }
         default  => undef,
       }
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -55,7 +55,6 @@ class dns::params {
       $sysconfig_resolvconf_integration = undef
 
       $dnssec_enable = if versioncmp($facts['os']['release']['major'], '9') >= 0 { undef } else { 'yes' }
-      }
     }
     /^(FreeBSD|DragonFly)$/: {
       $dnsdir             = '/usr/local/etc/namedb'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -54,7 +54,10 @@ class dns::params {
       # This option is not relevant for RedHat
       $sysconfig_resolvconf_integration = undef
 
-      $dnssec_enable = 'yes'
+      $dnssec_enable = $facts['os']['Family'] ? {
+        'RedHat' => if versioncmp($facts['os']['release']['major'], '8') >= 0 { undef } else { 'yes' },
+        default  => undef,
+      }
     }
     /^(FreeBSD|DragonFly)$/: {
       $dnsdir             = '/usr/local/etc/namedb'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -55,7 +55,6 @@ class dns::params {
       $sysconfig_resolvconf_integration = undef
 
       $dnssec_enable = if versioncmp($facts['os']['release']['major'], '9') >= 0 { undef } else { 'yes' }
-        default  => undef,
       }
     }
     /^(FreeBSD|DragonFly)$/: {

--- a/spec/classes/dns_init_spec.rb
+++ b/spec/classes/dns_init_spec.rb
@@ -104,7 +104,7 @@ describe 'dns' do
                               when 'Debian'
                                 ['9', '10', '18.04'].include?(facts[:os]['release']['major'])
                               when 'RedHat'
-                                true
+                                ['7', '8'].include?(facts[:os]['release']['major'])
                               else
                                 false
                               end


### PR DESCRIPTION
validated against EL (Redhat / CentOS / Rocky) 7 - 8 - 9 functions correctly.
Basic test against Fedora 35, which also works

Adds check of EL version greater than 7 and sets dnssec_enable parameter to undef if greater to allow the removal of the parameter from options.conf, which is a deprecated parameter in EL8 and later. This removes any warning in 9.15 and any breakage in 9.18 or later. Any version EL 7 or earlier includes the parameter allowing the user to set it on and off depending on if they want to use it, but the parameter is included as a valid parameter