### PR TITLE
stopped zone file from being created if zone type is forward

### DIFF
--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -137,7 +137,7 @@ define dns::zone (
     }
   }
 
-  if $manage_file {
+  if ($manage_file and $zonetype !='forward') {
     file { $zonefilename:
       ensure  => file,
       owner   => $dns::user,


### PR DESCRIPTION
evaluates if zone file is managed and zone file is not a forward, if the zone file is a forward type there is no value in creating the zone file as it will forward all requests.

There is a slim risk that someone may want a forward zone file that is forward first rather than forward only, upon research this usecase is obsolete in bind deployments and was a requirement due to some of the legacy capabilities in earlier versions of bind. 

If this risk is not an acceptable one to merge into the module, I can expand the evaluation to be zonetype and for include if the forward parameter is 'first' rather than 'only' which is the default for a foward zone.

I believe this is an acceptable use-case to ignore