### PR TITLE
logging channel error message typo faility to facility

### DIFF
--- a/manifests/logging/channel.pp
+++ b/manifests/logging/channel.pp
@@ -47,7 +47,7 @@ define dns::logging::channel (
 
   if $log_type == 'syslog' {
     if empty($syslog_facility) {
-      fail('dns::logging::channel: "syslog_faility" needs to be set with log type syslog')
+      fail('dns::logging::channel: "syslog_facility" needs to be set with log type syslog')
     }
   }
 


### PR DESCRIPTION
minor typo in syslog_facility error message from channel.pp detailing incorrect parameter