### PR TITLE
Remove legacy fact usage

### DIFF
--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -63,7 +63,7 @@
 define dns::zone (
   Array[String] $target_views                             = [],
   String $zonetype                                        = 'master',
-  String $soa                                             = $fqdn,
+  String $soa                                             = $facts['networking']['fqdn'],
   Boolean $reverse                                        = false,
   String $ttl                                             = '10800',
   Optional[Stdlib::IP::Address::V4] $soaip                = undef,

--- a/spec/acceptance/dns_spec.rb
+++ b/spec/acceptance/dns_spec.rb
@@ -15,7 +15,7 @@ describe 'Scenario: install bind' do
     end
   end
 
-  service_name = fact('osfamily') == 'Debian' ? 'bind9' : 'named'
+  service_name = fact('os.family') == 'Debian' ? 'bind9' : 'named'
 
   describe service(service_name) do
     it { is_expected.to be_enabled }

--- a/spec/acceptance/logging_spec.rb
+++ b/spec/acceptance/logging_spec.rb
@@ -32,7 +32,7 @@ describe 'Scenario: install bind with logging enabled' do
       end
     end
 
-    service_name = fact('osfamily') == 'Debian' ? 'bind9' : 'named'
+    service_name = fact('os.family') == 'Debian' ? 'bind9' : 'named'
 
     describe service(service_name) do
       it { is_expected.to be_enabled }

--- a/spec/acceptance/views_spec.rb
+++ b/spec/acceptance/views_spec.rb
@@ -36,7 +36,7 @@ describe 'Scenario: install bind with views enabled' do
       end
     end
 
-    service_name = fact('osfamily') == 'Debian' ? 'bind9' : 'named'
+    service_name = fact('os.family') == 'Debian' ? 'bind9' : 'named'
 
     describe service(service_name) do
       it { is_expected.to be_enabled }

--- a/spec/defines/dns_logging_category_spec.rb
+++ b/spec/defines/dns_logging_category_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'dns::logging::category' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:facts) { os_facts.merge(fqdn: 'puppetmaster.example.com') }
+      let(:facts) { override_facts(os_facts, networking: { fqdn: 'puppetmaster.example.com' }) }
       let(:pre_condition) { 'include dns' }
       let(:title) { 'test' }
       let(:logdir) { '/var/log/named' }

--- a/spec/defines/dns_logging_channel_spec.rb
+++ b/spec/defines/dns_logging_channel_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'dns::logging::channel' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:facts) { os_facts.merge(fqdn: 'puppetmaster.example.com') }
+      let(:facts) { override_facts(os_facts, networking: { fqdn: 'puppetmaster.example.com' }) }
       let(:pre_condition) { 'include dns' }
       let(:title) { 'test' }
       let(:logdir) { '/var/log/named' }

--- a/spec/defines/dns_zone_spec.rb
+++ b/spec/defines/dns_zone_spec.rb
@@ -13,7 +13,7 @@ describe 'dns::zone' do
 
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:facts) { os_facts.merge(fqdn: 'puppetmaster.example.com') }
+      let(:facts) { override_facts(os_facts, networking: { fqdn: 'puppetmaster.example.com' }) }
       let(:title) { "example.com" }
       let(:pre_condition) { 'include dns' }
       let(:zonefilepath) do

--- a/templates/options.conf.erb
+++ b/templates/options.conf.erb
@@ -26,7 +26,7 @@ listen-on-v6 { <%= scope.lookupvar('::dns::listen_on_v6') %>; };
 allow-recursion { <%= scope.lookupvar('::dns::allow_recursion').join("; ") %>; };
 <% end -%>
 
-<% if (@osfamily =~ /^(FreeBSD|DragonFly)$/) -%>
+<% if (@facts['os']['family'] =~ /^(FreeBSD|DragonFly)$/) -%>
 pid-file "/var/run/named/pid";
 <% end -%>
 


### PR DESCRIPTION
We can now run puppet without legacy facts:

```
puppet config set include_legacy_facts false
```

When doing so, the module fail to get the default value for `$dns::zone::soa`.  Fix it by using the `networking.fqdn` fact.

While here, adjust a few more legacy facts.
