### PR TITLE
Add support for Ubuntu Jammy (22.04)

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,7 +16,10 @@ class dns::params {
       $user               = 'bind'
       $group              = 'bind'
       $rndcconfgen        = '/usr/sbin/rndc-confgen'
-      $named_checkconf    = '/usr/sbin/named-checkconf'
+      $named_checkconf    = $facts['os']['name'] ? {
+        'Ubuntu' => if versioncmp($facts['os']['release']['major'], '22.04') >= 0 { '/usr/bin/named-checkconf' } else { '/usr/sbin/named-checkconf' },
+        default  => '/usr/sbin/named-checkconf',
+      }
       $sysconfig_file     = '/etc/default/bind9'
       $sysconfig_template = "dns/sysconfig.${facts['os']['family']}.erb"
       $sysconfig_startup_options = '-u bind'

--- a/metadata.json
+++ b/metadata.json
@@ -71,7 +71,8 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "18.04",
-        "20.04"
+        "20.04",
+        "22.04"
       ]
     },
     {

--- a/spec/classes/dns_init_spec.rb
+++ b/spec/classes/dns_init_spec.rb
@@ -29,6 +29,17 @@ describe 'dns' do
 
       let(:sbin) { facts[:os]['family'] == 'FreeBSD' ? '/usr/local/sbin' : '/usr/sbin' }
 
+      let(:checkconf) {
+        case facts[:os]['family']
+        when 'Debian'
+          ['22.04'].include?(facts[:os]['release']['major']) ? "/usr/bin/named-checkconf" : "/usr/sbin/named-checkconf"
+        when 'FreeBSD'
+          '/usr/local/sbin/named-checkconf'
+        else
+          '/usr/sbin/named-checkconf'
+        end
+      }
+
       let(:etc_named_directory) do
         case facts[:os]['family']
         when 'Debian'
@@ -134,8 +145,8 @@ describe 'dns' do
           verify_concat_fragment_exact_contents(catalogue, 'options.conf+10-main.dns', expected)
         end
 
-        it { should contain_concat("#{etc_named_directory}/zones.conf").with_validate_cmd("#{sbin}/named-checkconf %") }
-        it { should contain_concat("#{etc_directory}/named.conf").with_validate_cmd("#{sbin}/named-checkconf %") }
+        it { should contain_concat("#{etc_named_directory}/zones.conf").with_validate_cmd("#{checkconf} %") }
+        it { should contain_concat("#{etc_directory}/named.conf").with_validate_cmd("#{checkconf} %") }
         it do
           expected = [
             '// named.conf',


### PR DESCRIPTION
This change introduces initial support for Ubuntu Jammy.

Fixes: #227