### PR TITLE
Change sysconfig_file for Debian/Ubuntu to '/etc/default/named'

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,7 +20,11 @@ class dns::params {
         'Ubuntu' => if versioncmp($facts['os']['release']['major'], '22.04') >= 0 { '/usr/bin/named-checkconf' } else { '/usr/sbin/named-checkconf' },
         default  => '/usr/sbin/named-checkconf',
       }
-      $sysconfig_file     = '/etc/default/bind9'
+      $sysconfig_file     = $facts['os']['name'] ? {
+        'Debian' => '/etc/default/bind9',
+        'Ubuntu' => if versioncmp($facts['os']['release']['major'], '20.04') >= 0 { '/etc/default/named' } else { '/etc/default/bind9' },
+        default  => '/etc/default/named',
+      }
       $sysconfig_template = "dns/sysconfig.${facts['os']['family']}.erb"
       $sysconfig_startup_options = '-u bind'
       $sysconfig_resolvconf_integration = false

--- a/spec/classes/dns_init_spec.rb
+++ b/spec/classes/dns_init_spec.rb
@@ -403,13 +403,15 @@ describe 'dns' do
         }
       end
 
-      context 'sysconfig', if: ['Debian', 'RedHat'].include?(os_facts[:os]['family']) do
+      context 'sysconfig', if: ['Debian', 'RedHat', 'Ubuntu'].include?(os_facts[:os]['family']) do
         let(:sysconfig_named_path) do
           case facts[:os]['family']
           when 'RedHat'
             '/etc/sysconfig/named'
           when 'Debian'
             '/etc/default/bind9'
+          when 'Ubuntu'
+            facts[:os]['release']['major'] == '18.04' ? '/etc/default/bind9' : '/etc/default/named'
           end
         end
 


### PR DESCRIPTION
This was changed quite a while back, see https://salsa.debian.org/dns-team/bind9/-/commit/6fd962a36bb54e0106e001aff6cce056d54e2526.



Fixes https://github.com/theforeman/puppet-dns/issues/234