### PR TITLE
Change sysconfig_file for Debian/Ubuntu to '/etc/default/named'

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,7 +20,11 @@ class dns::params {
         'Ubuntu' => if versioncmp($facts['os']['release']['major'], '22.04') >= 0 { '/usr/bin/named-checkconf' } else { '/usr/sbin/named-checkconf' },
         default  => '/usr/sbin/named-checkconf',
       }
-      $sysconfig_file     = '/etc/default/bind9'
+      $sysconfig_file     = $facts['os']['name'] ? {
+        'Debian' => if versioncmp($facts['os']['release']['major'], '11') >= 0 { '/etc/default/named' } else { '/etc/default/bind9' },
+        'Ubuntu' => if versioncmp($facts['os']['release']['major'], '20.04') >= 0 { '/etc/default/named' } else { '/etc/default/bind9' },
+        default  => '/etc/default/named',
+      }
       $sysconfig_template = "dns/sysconfig.${facts['os']['family']}.erb"
       $sysconfig_startup_options = '-u bind'
       $sysconfig_resolvconf_integration = false

--- a/spec/classes/dns_init_spec.rb
+++ b/spec/classes/dns_init_spec.rb
@@ -409,7 +409,12 @@ describe 'dns' do
           when 'RedHat'
             '/etc/sysconfig/named'
           when 'Debian'
-            '/etc/default/bind9'
+            case facts[:os]['name']
+            when 'Debian'
+              facts[:os]['release']['major'] == '10' ? '/etc/default/bind9' : '/etc/default/named'
+            when 'Ubuntu'
+              facts[:os]['release']['major'] == '18.04' ? '/etc/default/bind9' : '/etc/default/named'
+            end
           end
         end
 


### PR DESCRIPTION
It is was changed quite a [while back](https://salsa.debian.org/dns-team/bind9/-/commit/6fd962a36bb54e0106e001aff6cce056d54e2526).

Fixes #234