### PR TITLE
Fix calling function empty() with Numeric value

### DIFF
--- a/manifests/logging/channel.pp
+++ b/manifests/logging/channel.pp
@@ -58,7 +58,7 @@ define dns::logging::channel (
     if empty($file_size) {
       fail('dns::logging::channel: "file_size" needs to be set with log type file')
     }
-    if empty($file_versions) {
+    if !$file_versions {
       fail('dns::logging::channel: "file_versions" needs to be set with log type file')
     }
   }


### PR DESCRIPTION
This produce a warning:

```
2023-11-19T05:33:05.421+02:00 WARN [qtp925335889-44] [puppetserver] Puppet Calling function empty() with Numeric value is deprecated. (file: /usr/local/etc/puppet/code/environments/production/modules/dns/manifests/logging/channel.pp, line: 61)
```

Since we have data-types in place (`Optional[Integer]`), we do not need
to care about an empty String.  Only `undef` will evaluate to false, and
it is the precise case we want to raise an error for.
