### PR TITLE
Add support for empty forwarders in master zone

### DIFF
--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -51,6 +51,9 @@
 # @param zonefilepath
 # @param filename
 # @param forward
+# @param master_empty_forwarders_enable
+#   Enable empty forwarders option in master zone.
+#   Applicable when forwarders are empty and zonetype is set to master.
 # @param forwarders
 # @param dns_notify
 # @param key_directory
@@ -87,6 +90,7 @@ define dns::zone (
   Boolean $manage_file_name                               = false,
   Boolean $replace_file                                   = false,
   Enum['first', 'only'] $forward                          = 'first',
+  Boolean $master_empty_forwarders_enable                 = false,
   Array $forwarders                                       = [],
   Optional[Enum['yes', 'no', 'explicit']] $dns_notify     = undef,
   Optional[Dns::UpdatePolicy] $update_policy              = undef,

--- a/templates/named.zone.erb
+++ b/templates/named.zone.erb
@@ -10,6 +10,12 @@ zone "<%= @zone %>" {
     file "<%= @zonefilename %>";
 <% end -%>
 <% if @zonetype == 'master' -%>
+<% if @forwarders.empty? && @master_empty_forwarders_enable -%>
+    forwarders {};
+<% end -%>
+<% unless @forwarders.empty? -%>
+    forwarders { <%= @forwarders.join('; ') %>; };
+<% end -%>
 <%   if @update_policy.is_a? String -%>
     update-policy <%= @update_policy %>;
 <%   elsif @update_policy -%>


### PR DESCRIPTION
This gives possibility to disable forwarding for delegated zone when server is authoritative for domain and global forwarding is set.