### PR TITLE
add support for the statistics-channels directive

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -98,6 +98,10 @@
 #   Specify a hash of controls. Each key is the name of a network, and its
 #   value is a hash containing 'port' => integer, 'keys' => array and
 #   'allowed_addresses' => array
+# @param statistics_channels
+#   Specify a hash of statistics-channels. Each key is the name of a network,
+#   and its value is a hash containing 'port' => integer and
+#   'allowed_addresses' => array
 # @param service_ensure
 #   The ensure attribute on the service
 # @param service_enable
@@ -170,6 +174,7 @@ class dns (
   Optional[Boolean] $sysconfig_disable_zone_checking                = $dns::params::sysconfig_disable_zone_checking,
   Hash[String[1], String] $sysconfig_additional_settings            = {},
   Hash[String, Hash[String, Data]] $controls                        = $dns::params::controls,
+  Hash[String, Hash[String, Data]] $statistics_channels             = {},
   Variant[Enum['running', 'stopped'], Boolean] $service_ensure      = 'running',
   Boolean $service_enable                                           = true,
   Optional[String[1]] $service_restart_command                      = undef,

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -53,6 +53,7 @@
 # @param forward
 # @param forwarders
 # @param dns_notify
+# @param zone_statistics
 # @param key_directory
 # @param inline_signing
 # @param dnssec_secure_to_insecure
@@ -89,6 +90,7 @@ define dns::zone (
   Enum['first', 'only'] $forward                          = 'first',
   Array $forwarders                                       = [],
   Optional[Enum['yes', 'no', 'explicit']] $dns_notify     = undef,
+  Optional[Enum['yes', 'no']] $zone_statistics            = undef,
   Optional[Dns::UpdatePolicy] $update_policy              = undef,
   Optional[Stdlib::Absolutepath] $key_directory           = undef,
   Optional[Enum['yes', 'no']] $inline_signing             = undef,

--- a/spec/classes/dns_init_spec.rb
+++ b/spec/classes/dns_init_spec.rb
@@ -353,6 +353,16 @@ describe 'dns' do
         ])}
       end
 
+      describe 'with statistics channels' do
+        let(:params) { { :statistics_channels => { '*' => { 'port' => 8053, 'allowed_addresses' => [ '127.0.0.0/8' ] } } } }
+
+        it { verify_concat_fragment_contents(catalogue, 'named.conf+10-main.dns', [
+          'statistics-channels  {',
+          '        inet * port 8053 allow { 127.0.0.0/8; };',
+          '};',
+        ])}
+      end
+
       describe 'with additional options' do
         let(:params) { { :additional_options => { 'max-cache-ttl' => 3600, 'max-ncache-ttl' => 3600 } } }
 

--- a/spec/defines/dns_zone_spec.rb
+++ b/spec/defines/dns_zone_spec.rb
@@ -459,6 +459,22 @@ describe 'dns::zone' do
         ])
         end
       end
+
+      context 'zone_statistics enabled' do
+        let(:params) { {
+          :zone_statistics => 'yes',
+        } }
+
+        it "should have valid zone configuration" do
+          verify_concat_fragment_exact_contents(catalogue, 'dns_zones+10__GLOBAL__example.com.dns', [
+          'zone "example.com" {',
+          '    type master;',
+          "    file \"#{zonefilepath}/db.example.com\";",
+          '    zone-statistics yes;',
+          '};',
+        ])
+        end
+      end
     end
   end
 end

--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -7,6 +7,14 @@ controls  {
         inet <%= control_ip %> port <%= control_hash['port'] %> allow { <% control_hash['allowed_addresses'].sort.each do |address| %><%= address %>; <% end %>} keys { <% control_hash['keys'].sort.each do |key| %>"<%= key %>"; <% end %>};
 <%- end -%>
 };
+<%- if scope.lookupvar('::dns::statistics_channels').any? -%>
+
+statistics-channels  {
+<%- scope.lookupvar('::dns::statistics_channels').sort_by {|k, v| k}.each do |stats_ip, stats_hash| -%>
+        inet <%= stats_ip %> port <%= stats_hash['port'] %> allow { <% stats_hash['allowed_addresses'].sort.each do |address| %><%= address %>; <% end %>};
+<%- end -%>
+};
+<%- end -%>
 
 options  {
         include "<%= scope.lookupvar('::dns::optionspath') %>";

--- a/templates/named.zone.erb
+++ b/templates/named.zone.erb
@@ -23,6 +23,9 @@ zone "<%= @zone %>" {
     allow-update { <%= @allow_update.join('; ') %>; };
 <%   end -%>
 <% end -%>
+<% if @zone_statistics -%>
+    zone-statistics <%= @zone_statistics %>;
+<% end -%>
 <% if @auto_dnssec -%>
     auto-dnssec <%= @auto_dnssec %>;
 <% end -%>


### PR DESCRIPTION
The statistics-channels statement declares communication channels to be used by system administrators to get access to statistics information of the name server. BIND will only start a listener if the directive is found in the configuration. The ACLs are rendered similar to the `controls` directive.

Statistics are not collected on a per-zone basis by default. To enable this behaviour, the defined type for zones has a new parameter to do so.