### PR TITLE
Add dns::dnssec_keygen function

### DIFF
--- a/lib/puppet/functions/dns/dnssec_keygen.rb
+++ b/lib/puppet/functions/dns/dnssec_keygen.rb
@@ -1,0 +1,28 @@
+require 'tmpdir'
+
+# @summary Generate a DNSSEC key
+Puppet::Functions.create_function(:'dns::dnssec_keygen') do
+  dispatch :keygen do
+    param 'String[1]', :name
+    param "String[1]", :algorithm
+    optional_param 'Integer[1, 4096]', :keysize
+    optional_param 'String[1]', :nametype
+    return_type 'Hash[String, String]'
+  end
+
+  def keygen(name, algorithm, keysize: nil, nametype: nil)
+    Dir.mktmpdir do |dir|
+      command = ['dnssec-keygen', '-K', dir]
+      command << '-a' << algorithm if algorithm
+      command << '-k' << keysize if keysize
+      command << '-n' << nametype if nametype
+      command << name
+      Puppet::Util::Execution.execute(command, failonfail: true)
+
+      path = Dir.glob(File.join(dir, "K#{name}.+*.private")).first
+      raise Exception, 'No file private key generated' unless path
+
+      File.readlines(path, chomp: true).to_h { |line| line.split(': ', 2) }
+    end
+  end
+end

--- a/spec/functions/dnssec_keygen_spec.rb
+++ b/spec/functions/dnssec_keygen_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe 'dns::dnssec_keygen' do
+  it do
+    expect(Puppet::Util::Execution).to receive(:execute).with(['dnssec-keygen', '-K', kind_of(String), '-a', 'ED25519', 'myname'], failonfail: true) do |command, **kwargs|
+      dir = command[2]
+      content = <<~PRIVATE
+        Private-key-format: v1.3
+        Algorithm: 15 (ED25519)
+        PrivateKey: 7F1qiEoDLvTLlOv+xY46MyI3vtcncqme+DExkz5YiRg=
+        Created: 20240130104725
+        Publish: 20240130104725
+        Activate: 20240130104725
+      PRIVATE
+      File.write(File.join(dir, 'Kmyname.+015+04808.private'), content)
+    end
+    expected = {
+      'Private-key-format' => 'v1.3',
+      'Algorithm' => '15 (ED25519)',
+      'PrivateKey' => '7F1qiEoDLvTLlOv+xY46MyI3vtcncqme+DExkz5YiRg=',
+      'Created' => '20240130104725',
+      'Publish' => '20240130104725',
+      'Activate' => '20240130104725',
+    }
+
+    is_expected.to run.with_params('myname', 'ED25519').and_return(expected)
+  end
+end


### PR DESCRIPTION
This wraps dnssec-keygen and returns the data in a structured format. The result can be used to secure communications. It always generates a random key and the resulting data should be cached or otherwise made idempotent.