### PR TITLE
Update ensure_packages->stdlib::ensure_packages; require stdlib 9

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -2,7 +2,7 @@
 # @api private
 class dns::install {
   if ! empty($dns::dns_server_package) {
-    ensure_packages([$dns::dns_server_package])
+    stdlib::ensure_packages([$dns::dns_server_package])
     $pkg_req = Package[$dns::dns_server_package]
   } else {
     $pkg_req = undef

--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 10.0.0"
+      "version_requirement": ">= 9.0.0 < 10.0.0"
     }
   ],
   "requirements": [


### PR DESCRIPTION
The `ensure_packages()` function is deprecated with stdlib 9. It triggers a catalog compilation warning on Puppet 7 and a catgalog compilation error on Pupppet 8. This PR switches to the successor, `stdlib::ensure_packages()`. This function got introduced in stdlib 9.