### PR TITLE
Add response-policy to dns::view

### DIFF
--- a/manifests/view.pp
+++ b/manifests/view.pp
@@ -38,6 +38,14 @@
 #    not to be unmanaged to be effective.
 # @param order
 #   The order parameter to the concat fragment.
+# @param response_policy
+#   Optional. An array of response policy configurations for the view in the
+#   following format:
+#   [{'zone' => '<ZONE_NAME>', 'policy' => '<POLICY_ACTION>', 'log' => true|false,
+#     'max_policy_ttl' => <TTL_VALUE>, 'cname_domain' => '<CNAME_DOMAIN>'}]
+#   Example: [{'zone' => 'example.com', 'policy' => 'passthru', 'log' => true,
+#              'max_policy_ttl' => 3600}, {'zone' => 'example.net',
+#              'policy' => 'cname', 'cname_domain' => 'example.com'}]
 #
 define dns::view (
   Array[String]                         $match_clients        = [],
@@ -57,6 +65,7 @@ define dns::view (
   Boolean                               $include_localzones   = true,
   Boolean                               $include_defaultzones = true,
   String                                $order                = '-',
+  Optional[Dns::ResponsePolicy]         $response_policy      = undef,
 ) {
   unless $dns::enable_views {
     fail('Must set $dns::enable_views to true in order to use dns::view')

--- a/templates/named.view_header.erb
+++ b/templates/named.view_header.erb
@@ -41,6 +41,13 @@ view "<%= @title %>" {
 <% if @dnssec_validation -%>
     dnssec-validation <%= @dnssec_validation %>;
 <% end -%>
+<% if @response_policy -%>
+    response-policy {
+<% @response_policy.each do |policy| -%>
+        zone "<%= policy['zone'] %>"<% if policy['policy'] -%> policy <%= policy['policy'] %><% end -%><% if policy['policy'] == 'cname' && policy['cname_domain'] -%> <%= policy['cname_domain'] %><% end -%><% if policy['max_policy_ttl'] -%> max-policy-ttl <%= policy['max_policy_ttl'] %><% end -%><% if policy['log'] -%> log <%= policy['log'] %><% end -%>;
+<% end -%>
+    };
+<% end -%>
 
 <% if @include_localzones -%>
 <% if scope.lookupvar("::dns::localzonepath") != 'unmanaged' -%>

--- a/types/responsepolicy.pp
+++ b/types/responsepolicy.pp
@@ -1,0 +1,12 @@
+type Dns::ResponsePolicy = Array[
+  Struct[{
+    zone           => String[1],
+    policy         => Optional[Enum[
+      'given', 'disabled', 'passthru', 'drop',
+      'nxdomain', 'nodata', 'tcp-only', 'cname'
+    ]],
+    cname_domain   => Optional[String[1]],
+    max_policy_ttl => Optional[Integer],
+    log            => Optional[Boolean]
+  }], 1, 32
+]


### PR DESCRIPTION
This PR, try to addresses the issue https://github.com/theforeman/puppet-dns/issues/251, which involves adding a response-policy to the `dns::view`.

Below example shows how to use the `dns::view` defined type with the `response-policy` parameter:
```
dns::view { 'example_view':
  # ...
  response_policy      => [
    {
      'zone'           => 'example.com',
      'policy'         => 'passthru',
      'max_policy_ttl' => 3600,
      'log'            => true,
    },
    {
      'zone'         => 'example.net',
      'policy'       => 'cname',
      'cname_domain' => 'example.net',
    },
  ],
}
```

It will generate the following `BIND` configuration:
```
view "example_view" {
    # ...
    response-policy {
        zone "example.com" policy passthru max-policy-ttl 3600 log true;
        zone "example.net" policy cname example.net;
    };
}
```

The `response-policy` may support a few other parameters, which I have not included for simplicity.

