### PR TITLE
Refs #37121 - Add dns::tsig_keygen function

### DIFF
--- a/lib/puppet/functions/dns/tsig_keygen.rb
+++ b/lib/puppet/functions/dns/tsig_keygen.rb
@@ -1,0 +1,29 @@
+require 'tmpdir'
+
+# @summary Generate a TSIG key
+Puppet::Functions.create_function(:'dns::tsig_keygen') do
+  dispatch :keygen do
+    param 'String[1]', :name
+    optional_param "String[1]", :algorithm
+    return_type 'Hash[String, String]'
+  end
+
+  def keygen(name, algorithm = nil)
+    command = ['tsig-keygen']
+    command << '-a' << algorithm if algorithm
+    command << name
+    output = Puppet::Util::Execution.execute(command, failonfail: true)
+
+    header, rest = output.split('{', 2)
+    inner, _, _ = rest.rpartition('}').first
+    options = inner.strip.split(';').to_h do |line|
+      match = line.match(/^\s*(?<option>[a-z]+)\s+(?<quote>"?)(?<value>.+)\k<quote>\s*$/)
+      [match[:option], match[:value]]
+    end
+
+    {
+      'name' => header.match(/key "(.+)\s*"/)[1],
+      'output' => output,
+    }.merge(options)
+  end
+end

--- a/spec/functions/tsig_keygen_spec.rb
+++ b/spec/functions/tsig_keygen_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe 'dns::tsig_keygen' do
+  it 'without algorithm' do
+    output = <<~OUTPUT
+      key "myname" {
+      \talgorithm hmac-sha256;
+      \tsecret "r9SlgbRyks9gGTAIbnjwGX1UxVxY8k0q1wbyiqTolLs=";
+      };
+    OUTPUT
+
+    expect(Puppet::Util::Execution).to receive(:execute).with(['tsig-keygen', 'myname'], failonfail: true).and_return(output)
+    expected = {
+      'name' => 'myname',
+      'algorithm' => 'hmac-sha256',
+      'secret' => 'r9SlgbRyks9gGTAIbnjwGX1UxVxY8k0q1wbyiqTolLs=',
+      'output' => output,
+    }
+
+    is_expected.to run.with_params('myname').and_return(expected)
+  end
+
+  it 'with algorithm' do
+    output = <<~OUTPUT
+      key "myname" {
+      \talgorithm hmac-md5;
+      \tsecret "RHwgNynk1A7cc+fnH2rxqQ==";
+      };
+    OUTPUT
+
+    expect(Puppet::Util::Execution).to receive(:execute).with(['tsig-keygen', '-a', 'hmac-md5', 'myname'], failonfail: true).and_return(output)
+    expected = {
+      'name' => 'myname',
+      'algorithm' => 'hmac-md5',
+      'secret' => 'RHwgNynk1A7cc+fnH2rxqQ==',
+      'output' => output,
+    }
+
+    is_expected.to run.with_params('myname', 'hmac-md5').and_return(expected)
+  end
+end


### PR DESCRIPTION
This wraps tsig-keygen and returns the data in a structured format. The result can be used to secure communications. It always generates a random key and the resulting data should be cached or otherwise made idempotent.