### PR TITLE
Add AlmaLinux 8 & 9 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,6 @@ jobs:
     name: Puppet
     uses: voxpupuli/gha-puppet/.github/workflows/beaker.yml@v2
     with:
-      pidfile_workaround: 'CentOS'
+      pidfile_workaround: 'CentOS,AlmaLinux'
       rubocop: false
       cache-version: '1'

--- a/.sync.yml
+++ b/.sync.yml
@@ -1,2 +1,2 @@
 .github/workflows/ci.yml:
-  pidfile_workaround: CentOS
+  pidfile_workaround: CentOS,AlmaLinux

--- a/metadata.json
+++ b/metadata.json
@@ -90,6 +90,13 @@
       "operatingsystemrelease": [
         "4"
       ]
+    },
+    {
+      "operatingsystem": "AlmaLinux",
+      "operatingsystemrelease": [
+        "8",
+        "9"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Added AlmaLinux 8 and 9 to the supported operating systems in metadata.json.

These changes ensure that we start testing with AlmaLinux 8 and 9 instead of CentOS 8 Stream. This update is part of our transition to better support AlmaLinux in our Puppet modules.

See, for details: https://github.com/theforeman/foreman-infra/issues/2087