### PR TITLE
Add parameter to set disable-empty-zone option

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -134,6 +134,9 @@
 #   A hash of logging categories to be created. See dns::logging::category for options.
 # @param logging_channels
 #   A hash of logging channels to be created. See dns::logging::channel for options.
+# @param disable_empty_zones
+#   A hash containing a list of empty zones that shouldn't be created by bind
+#   See: https://kb.isc.org/docs/aa-00800
 #
 # @see dns::zone
 # @see dns::key
@@ -186,6 +189,7 @@ class dns (
   Hash[String, Hash] $keys                                          = {},
   Hash[String, Hash] $logging_categories                            = {},
   Hash[String, Hash] $logging_channels                              = {},
+  Array[Stdlib::Fqdn] $disable_empty_zones                          = [],
 ) inherits dns::params {
   include dns::install
   include dns::config

--- a/spec/classes/dns_init_spec.rb
+++ b/spec/classes/dns_init_spec.rb
@@ -363,6 +363,15 @@ describe 'dns' do
         ])}
       end
 
+      describe 'with disable empty zones' do
+        let(:params) { { :disable_empty_zones => ["16.172.IN-ADDR.ARPA", "17.172.IN-ADDR.ARPA"] } }
+
+        it { verify_concat_fragment_contents(catalogue, 'options.conf+10-main.dns', [
+          'disable-empty-zone "16.172.IN-ADDR.ARPA";',
+          'disable-empty-zone "17.172.IN-ADDR.ARPA";'
+        ])}
+      end
+
       describe 'with additional options' do
         let(:params) { { :additional_options => { 'max-cache-ttl' => 3600, 'max-ncache-ttl' => 3600 } } }
 

--- a/templates/options.conf.erb
+++ b/templates/options.conf.erb
@@ -30,6 +30,10 @@ allow-recursion { <%= scope.lookupvar('::dns::allow_recursion').join("; ") %>; }
 pid-file "/var/run/named/pid";
 <% end -%>
 
+<%- scope.lookupvar('::dns::disable_empty_zones').sort.each do |disable_empty_zone| -%>
+disable-empty-zone "<%= disable_empty_zone %>";
+<%- end -%>
+
 <%- scope.lookupvar('::dns::additional_options').sort_by {|k, v| k}.each do |option, value| -%>
 <%= option %> <%= value %>;
 <%- end -%>


### PR DESCRIPTION
disable-empty-zone allows one to disable the automatically created zones

Fixes: #255