### PR TITLE
Fixes #37604 - Validate DNS forwarders

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -155,7 +155,7 @@ class dns (
   Variant[Enum['unmanaged'], Stdlib::Absolutepath] $localzonepath   = $dns::params::localzonepath,
   Variant[Enum['unmanaged'], Stdlib::Absolutepath] $defaultzonepath = $dns::params::defaultzonepath,
   Optional[Enum['only', 'first']] $forward                          = undef,
-  Array[String] $forwarders                                         = [],
+  Array[Dns::Forwarder] $forwarders                                 = [],
   Variant[String, Boolean] $listen_on_v6                            = 'any',
   Enum['yes', 'no'] $recursion                                      = 'yes',
   Array[String] $allow_recursion                                    = ['localnets', 'localhost'],

--- a/manifests/view.pp
+++ b/manifests/view.pp
@@ -48,7 +48,7 @@ define dns::view (
   Array[String]                         $allow_query          = [],
   Array[String]                         $allow_query_cache    = [],
   Array[String]                         $also_notify          = [],
-  Array[String]                         $forwarders           = [],
+  Array[Dns::Forwarder]                 $forwarders           = [],
   Optional[Enum['only','first']]        $forward              = undef,
   Optional[Enum['yes','no']]            $recursion            = undef,
   Optional[Enum['yes','no']]            $dnssec_enable        = undef,

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -94,7 +94,7 @@ define dns::zone (
   Boolean $replace_file                                   = false,
   Enum['first', 'only'] $forward                          = 'first',
   Boolean $master_empty_forwarders_enable                 = false,
-  Array $forwarders                                       = [],
+  Array[Dns::Forwarder] $forwarders                       = [],
   Optional[Enum['yes', 'no', 'explicit']] $dns_notify     = undef,
   Optional[Enum['yes', 'no']] $zone_statistics            = undef,
   Optional[Dns::UpdatePolicy] $update_policy              = undef,

--- a/spec/type_aliases/forwarder_spec.rb
+++ b/spec/type_aliases/forwarder_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe 'Dns::Forwarder' do
+  it { is_expected.not_to allow_value(nil) }
+  it { is_expected.not_to allow_value('') }
+
+  describe 'IPv4' do
+    it { is_expected.to allow_value('192.0.2.1') }
+    it { is_expected.to allow_value('192.0.2.1 port 5353') }
+    it { is_expected.to allow_value('192.168.254.254    port     5353') }
+    it { is_expected.to allow_value('192.168.254.254    port     65534') }
+  end
+
+  describe 'IPv6' do
+    it { is_expected.to allow_value('::1') }
+    it { is_expected.to allow_value('::1 port 5353') }
+    it { is_expected.to allow_value('2001:db8:1234:5678:9ABC:DEF::1') }
+    it { is_expected.to allow_value('2001:db8:1234:5678:9ABC:DEF::1 port 5353') }
+    it { is_expected.to allow_value('2001:0db8:1234:5678:9ABC:0DEF:0000:0001') }
+    it { is_expected.to allow_value('2001:0db8:1234:5678:9ABC:0DEF:0000:0001 port 65534') }
+  end
+end

--- a/types/forwarder.pp
+++ b/types/forwarder.pp
@@ -1,0 +1,11 @@
+# @summary a DNS forwarder entry
+#
+# A forwarder is an IP address (v4 or v6) with optionally followed a port.
+# Since we can't compose patterns, this copies stdlib's implementation for v4.
+# For v6 it uses the default type and grossly simplifies the port check for simplicity.
+type Dns::Forwarder = Variant[
+  Pattern[/\A([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\.([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])){3}(\s+port\s+[0-9]{1,5})?\z/],
+  Stdlib::IP::Address::V6::Nosubnet,
+  # This is a really gross simplification of IPv6
+  Pattern[/(\A(:{0,2}[[:xdigit:]]{1,4}){1,8}\s+port\s[0-9]{1,5}\Z)/],
+]


### PR DESCRIPTION
A user can input an invalid value and the service will refuse to start up. We can catch this in data types, preventing service downtime.