### PR TITLE
Drop RHEL 7, CentOS 7 & 8, Scientific 7 & Debian 10; Add RHEL 9 & Fedora 39 & 40

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -28,7 +28,7 @@ class dns::params {
       # This option is not relevant for Debian
       $sysconfig_disable_zone_checking = undef
 
-      $dnssec_enable = undef,
+      $dnssec_enable = undef
     }
     'RedHat': {
       $dnsdir             = '/etc'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,11 +20,7 @@ class dns::params {
         'Ubuntu' => if versioncmp($facts['os']['release']['major'], '22.04') >= 0 { '/usr/bin/named-checkconf' } else { '/usr/sbin/named-checkconf' },
         default  => if versioncmp($facts['os']['release']['major'], '12') >= 0 { '/usr/bin/named-checkconf' } else { '/usr/sbin/named-checkconf' },
       }
-      $sysconfig_file     = $facts['os']['name'] ? {
-        'Debian' => if versioncmp($facts['os']['release']['major'], '11') >= 0 { '/etc/default/named' } else { '/etc/default/bind9' },
-        'Ubuntu' => if versioncmp($facts['os']['release']['major'], '20.04') >= 0 { '/etc/default/named' } else { '/etc/default/bind9' },
-        default  => '/etc/default/named',
-      }
+      $sysconfig_file     = '/etc/default/named'
       $sysconfig_template = "dns/sysconfig.${facts['os']['family']}.erb"
       $sysconfig_startup_options = '-u bind'
       $sysconfig_resolvconf_integration = false
@@ -32,11 +28,7 @@ class dns::params {
       # This option is not relevant for Debian
       $sysconfig_disable_zone_checking = undef
 
-      $dnssec_enable = $facts['os']['name'] ? {
-        'Debian' => if versioncmp($facts['os']['release']['major'], '11') >= 0 { undef } else { 'yes' },
-        'Ubuntu' => if versioncmp($facts['os']['release']['major'], '20.04') >= 0 { undef } else { 'yes' },
-        default  => undef,
-      }
+      $dnssec_enable = undef,
     }
     'RedHat': {
       $dnsdir             = '/etc'

--- a/metadata.json
+++ b/metadata.json
@@ -35,7 +35,8 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "8"
+        "8",
+        "9"
       ]
     },
     {
@@ -47,8 +48,8 @@
     {
       "operatingsystem": "Fedora",
       "operatingsystemrelease": [
-        "37",
-        "38"
+        "39",
+        "40"
       ]
     },
     {

--- a/metadata.json
+++ b/metadata.json
@@ -35,22 +35,13 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7",
         "8"
       ]
     },
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7",
-        "8",
         "9"
-      ]
-    },
-    {
-      "operatingsystem": "Scientific",
-      "operatingsystemrelease": [
-        "7"
       ]
     },
     {
@@ -63,7 +54,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "10",
         "11",
         "12"
       ]
@@ -71,7 +61,6 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "18.04",
         "20.04",
         "22.04"
       ]

--- a/spec/classes/dns_init_spec.rb
+++ b/spec/classes/dns_init_spec.rb
@@ -118,14 +118,6 @@ describe 'dns' do
 
         it { should contain_concat(options_path) }
         it do
-          has_dnssec_enable = case facts[:os]['family']
-                              when 'Debian'
-                                ['9', '10', '18.04'].include?(facts[:os]['release']['major'])
-                              when 'RedHat'
-                                ['7', '8'].include?(facts[:os]['release']['major'])
-                              else
-                                false
-                              end
           expected = [
             "directory \"#{var_path}\";",
             'recursion yes;',
@@ -136,7 +128,7 @@ describe 'dns' do
             'allow-recursion { localnets; localhost; };'
           ]
 
-          expected << 'dnssec-enable yes;' if has_dnssec_enable
+          expected << 'dnssec-enable yes;' if facts[:os]['family'] == 'RedHat' && facts[:os]['release']['major'] == '8'
 
           if facts[:os]['family'] == 'FreeBSD'
             expected << 'pid-file "/var/run/named/pid";'
@@ -428,12 +420,7 @@ describe 'dns' do
           when 'RedHat'
             '/etc/sysconfig/named'
           when 'Debian'
-            case facts[:os]['name']
-            when 'Debian'
-              facts[:os]['release']['major'] == '10' ? '/etc/default/bind9' : '/etc/default/named'
-            when 'Ubuntu'
-              facts[:os]['release']['major'] == '18.04' ? '/etc/default/bind9' : '/etc/default/named'
-            end
+            '/etc/default/named'
           end
         end
 


### PR DESCRIPTION
These are end of life and testing on them isn't possible anymore.