### PR TITLE
BIND 9.18 compatiblity on Ubuntu 20.04

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,7 +17,7 @@ class dns::params {
       $group              = 'bind'
       $rndcconfgen        = '/usr/sbin/rndc-confgen'
       $named_checkconf    = $facts['os']['name'] ? {
-        'Ubuntu' => if versioncmp($facts['os']['release']['major'], '22.04') >= 0 { '/usr/bin/named-checkconf' } else { '/usr/sbin/named-checkconf' },
+        'Ubuntu' => '/usr/bin/named-checkconf',
         default  => if versioncmp($facts['os']['release']['major'], '12') >= 0 { '/usr/bin/named-checkconf' } else { '/usr/sbin/named-checkconf' },
       }
       $sysconfig_file     = '/etc/default/named'

--- a/spec/classes/dns_init_spec.rb
+++ b/spec/classes/dns_init_spec.rb
@@ -32,7 +32,7 @@ describe 'dns' do
       let(:checkconf) {
         case facts[:os]['family']
         when 'Debian'
-          ['22.04', '12'].include?(facts[:os]['release']['major']) ? "/usr/bin/named-checkconf" : "/usr/sbin/named-checkconf"
+          facts[:os]['release']['major'] != '11' ? "/usr/bin/named-checkconf" : "/usr/sbin/named-checkconf"
         when 'FreeBSD'
           '/usr/local/sbin/named-checkconf'
         else


### PR DESCRIPTION
A security update on Ubuntu 20.04 brought BIND 9.18 which moves named-checkconf from /usr/sbin to /usr/bin.

This removes the need for the conditional because now all supported versions use /usr/bin.