### PR TITLE
fix path to named-checkconf on FreeBSD/DragonFly BSD

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -69,7 +69,7 @@ class dns::params {
       $user               = 'bind'
       $group              = 'bind'
       $rndcconfgen        = '/usr/local/sbin/rndc-confgen'
-      $named_checkconf    = '/usr/local/sbin/named-checkconf'
+      $named_checkconf    = '/usr/local/bin/named-checkconf'
       # The sysconfig settings are not relevant for FreeBSD
       $sysconfig_file     = undef
       $sysconfig_template = undef

--- a/metadata.json
+++ b/metadata.json
@@ -69,7 +69,8 @@
     {
       "operatingsystem": "FreeBSD",
       "operatingsystemrelease": [
-        "11"
+        "13",
+        "14"
       ]
     },
     {

--- a/spec/classes/dns_init_spec.rb
+++ b/spec/classes/dns_init_spec.rb
@@ -34,7 +34,7 @@ describe 'dns' do
         when 'Debian'
           facts[:os]['release']['major'] != '11' ? "/usr/bin/named-checkconf" : "/usr/sbin/named-checkconf"
         when 'FreeBSD'
-          '/usr/local/sbin/named-checkconf'
+          '/usr/local/bin/named-checkconf'
         else
           '/usr/sbin/named-checkconf'
         end


### PR DESCRIPTION
Fixes the following error:

```
Error: Execution of '/usr/local/sbin/named-checkconf /usr/local/etc/namedb/zones.conf20250112-57376-i5p19x' returned 1: Error: Could not execute posix command: No such file or directory - /usr/local/sbin/named-checkconf
```

Turns out the path to `named-checkconf` is incorrect:

```
$ uname -o
FreeBSD
$ which named-checkconf
/usr/local/bin/named-checkconf
```