### PR TITLE
Split zones across multiple named.conf file

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -14,6 +14,13 @@ class dns::config {
     validate_cmd => $validate_cmd,
   }
 
+  concat { '/etc/bind/named.conf.cust':
+    owner        => root,
+    group        => $dns::params::group,
+    mode         => '0640',
+    validate_cmd => $validate_cmd,
+  }
+
   if $dns::enable_views {
     file { $dns::viewconfigpath:
       ensure => directory,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -14,7 +14,7 @@ class dns::config {
     validate_cmd => $validate_cmd,
   }
 
-  concat { '/etc/bind/primary/named.conf.cust':
+  concat { '/etc/bind/named.conf.cust':
     owner        => root,
     group        => $dns::params::group,
     mode         => '0640',

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -14,11 +14,13 @@ class dns::config {
     validate_cmd => $validate_cmd,
   }
 
-  concat { '/etc/bind/named.conf.cust':
-    owner        => root,
-    group        => $dns::params::group,
-    mode         => '0640',
-    validate_cmd => $validate_cmd,
+  $dns::additional_zones.keys.each |$namedconfname| {
+    concat { "${dns::dnsdir}/${namedconfname}":
+      owner        => root,
+      group        => $dns::params::group,
+      mode         => '0640',
+      validate_cmd => $validate_cmd,
+    }
   }
 
   if $dns::enable_views {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -14,7 +14,7 @@ class dns::config {
     validate_cmd => $validate_cmd,
   }
 
-  concat { '/etc/bind/named.conf.cust':
+  concat { '/etc/bind/primary/named.conf.cust':
     owner        => root,
     group        => $dns::params::group,
     mode         => '0640',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -215,6 +215,6 @@ class dns (
       $tmp = { $zone_name => $named_conf_path + $zone_data }
       $tmp
     }
-    create_resources('dns::zone', $zone_resource)
+    create_resources('dns::zone', $zone_resource[0])
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -208,4 +208,11 @@ class dns (
   create_resources('dns::zone', $additional_zones)
   create_resources('dns::logging::category', $logging_categories)
   create_resources('dns::logging::channel', $logging_channels)
+
+  additional_zones.each |$namedconf, $additional_zone| {
+    $zone_resource = $additional_zone.each |$zone_name, $zone_data| {
+      { $zone_name => { 'nameconfpath' => "${dns::zonefilepath}/${namedconf}"} + $zone_data }
+    }
+    create_resources('dns::zone', $zone_resource)
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -209,9 +209,11 @@ class dns (
   create_resources('dns::logging::category', $logging_categories)
   create_resources('dns::logging::channel', $logging_channels)
 
-  additional_zones.each |$namedconf, $additional_zone| {
+  $additional_zones.each |$namedconf, $additional_zone| {
     $zone_resource = $additional_zone.each |$zone_name, $zone_data| {
-      { $zone_name => {{ 'nameconfpath' => "${dns::zonefilepath}/${namedconf}" } + $zone_data } }
+      $named_conf_path = { 'nameconfpath' => $namedconf }
+      $tmp = { $zone_name => $named_conf_path + $zone_data }
+      $tmp
     }
     create_resources('dns::zone', $zone_resource)
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -210,7 +210,7 @@ class dns (
   create_resources('dns::logging::channel', $logging_channels)
 
   $additional_zones.each |$namedconf, $additional_zone| {
-    $zone_resource = $additional_zone.each |$zone_name, $zone_data| {
+    $zone_resource = $additional_zone.map |$zone_name, $zone_data| {
       $named_conf_path = { 'nameconfpath' => $namedconf }
       $tmp = { $zone_name => $named_conf_path + $zone_data }
       $tmp

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -130,6 +130,8 @@
 #   like localzonepath inclusion.
 # @param zones
 #   A hash of zones to be created. See dns::zone for options.
+# @param additional_zones
+#   A hash of named.conf file and above zone hash
 # @param keys
 #   A hash of keys to be created. See dns::key for options.
 # @param logging_categories
@@ -189,6 +191,7 @@ class dns (
   Array[String] $additional_directives                              = [],
   Boolean $enable_views                                             = false,
   Hash[String, Hash] $zones                                         = {},
+  Hash[String, Hash] $additional_zones                              = {},
   Hash[String, Hash] $keys                                          = {},
   Hash[String, Hash] $logging_categories                            = {},
   Hash[String, Hash] $logging_channels                              = {},
@@ -202,6 +205,7 @@ class dns (
 
   create_resources('dns::key', $keys)
   create_resources('dns::zone', $zones)
+  create_resources('dns::zone', $additional_zones)
   create_resources('dns::logging::category', $logging_categories)
   create_resources('dns::logging::channel', $logging_channels)
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -211,7 +211,7 @@ class dns (
 
   $additional_zones.each |$namedconf, $additional_zone| {
     $zone_resource = $additional_zone.map |$zone_name, $zone_data| {
-      $named_conf_path = { 'nameconfpath' => $namedconf }
+      $named_conf_path = { 'nameconfpath' => "${dns::zonefilepath}/${namedconf}" }
       $tmp = { $zone_name => $named_conf_path + $zone_data }
       $tmp
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -205,7 +205,7 @@ class dns (
 
   create_resources('dns::key', $keys)
   create_resources('dns::zone', $zones)
-  create_resources('dns::zone', $additional_zones)
+  # create_resources('dns::zone', $additional_zones)
   create_resources('dns::logging::category', $logging_categories)
   create_resources('dns::logging::channel', $logging_channels)
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -205,16 +205,13 @@ class dns (
 
   create_resources('dns::key', $keys)
   create_resources('dns::zone', $zones)
-  # create_resources('dns::zone', $additional_zones)
   create_resources('dns::logging::category', $logging_categories)
   create_resources('dns::logging::channel', $logging_channels)
 
   $additional_zones.each |$namedconf, $additional_zone| {
-    $zone_resource = $additional_zone.map |$zone_name, $zone_data| {
-      $named_conf_path = { 'nameconfpath' => "${dns::dnsdir}/${namedconf}" }
-      $tmp = { $zone_name => $named_conf_path + $zone_data }
-      $tmp
+    $zone_resource = $additional_zone.reduce({}) |$zone_memo, $zone_x| {
+      $zone_memo + { $zone_x[0] => { 'nameconfpath' => "${dns::dnsdir}/${namedconf}" } + $additional_zone[$zone_x[0]] }
     }
-    create_resources('dns::zone', $zone_resource[0])
+    create_resources('dns::zone', $zone_resource)
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -211,7 +211,7 @@ class dns (
 
   additional_zones.each |$namedconf, $additional_zone| {
     $zone_resource = $additional_zone.each |$zone_name, $zone_data| {
-      { $zone_name => { 'nameconfpath' => "${dns::zonefilepath}/${namedconf}"} + $zone_data }
+      { $zone_name => {{ 'nameconfpath' => "${dns::zonefilepath}/${namedconf}" } + $zone_data } }
     }
     create_resources('dns::zone', $zone_resource)
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -211,7 +211,7 @@ class dns (
 
   $additional_zones.each |$namedconf, $additional_zone| {
     $zone_resource = $additional_zone.map |$zone_name, $zone_data| {
-      $named_conf_path = { 'nameconfpath' => "${dns::zonefilepath}/${namedconf}" }
+      $named_conf_path = { 'nameconfpath' => "${dns::dnsdir}/${namedconf}" }
       $tmp = { $zone_name => $named_conf_path + $zone_data }
       $tmp
     }

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -56,6 +56,8 @@
 #   Applicable when forwarders are empty and zonetype is set to master.
 # @param forwarders
 # @param dns_notify
+# @param nameconfpath
+#   Moved to class parameter to allow zones split across multiple named.conf.x files
 # @param zone_statistics
 # @param key_directory
 # @param inline_signing
@@ -95,6 +97,7 @@ define dns::zone (
   Enum['first', 'only'] $forward                          = 'first',
   Boolean $master_empty_forwarders_enable                 = false,
   Array[Dns::Forwarder] $forwarders                       = [],
+  String $nameconfpath                                    = $dns::publicviewpath,
   Optional[Enum['yes', 'no', 'explicit']] $dns_notify     = undef,
   Optional[Enum['yes', 'no']] $zone_statistics            = undef,
   Optional[Dns::UpdatePolicy] $update_policy              = undef,
@@ -131,11 +134,11 @@ define dns::zone (
 
   $_target_views.each |$view| {
     $target = $view ? {
-      '_GLOBAL_' => $dns::publicviewpath,
+      '_GLOBAL_' => $nameconfpath,
       default    => "${dns::viewconfigpath}/${view}.conf",
     }
 
-    concat::fragment { "dns_zones+10_${view}_${title}.dns":
+    concat::fragment { "dns_zones+10_${nameconfpath}_${view}_${title}.dns":
       target  => $target,
       content => template('dns/named.zone.erb'),
       order   => "${view}-11-${zone}-1",


### PR DESCRIPTION
The change is for spreading zones across multiple name.conf.x as well as the main named.conf file.
Added nameconfpath to zone.pp's class parameters, allowing it to be passed within zone data.
I used a reduce function to move the named.conf filename into the zone data, so the hiera data is shorter and cleaner.
I don't think this affects normal functionality.
```
dns::additional_zones:
  'named.conf.other':
    'adomain.org':
      'manage_file': false
      'manage_file_name': true
    'anotherdomian.com':
      'manage_file': false
      'manage_file_name': true
  'named.conf.more':
    'smoother.domain':
      'manage_file': false
      'manage_file_name': true