### PR TITLE
Add support for Debian 13

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,8 +7,14 @@ class dns::params {
       $vardir             = '/var/cache/bind'
       $optionspath        = "${dnsdir}/named.conf.options"
       $zonefilepath       = "${vardir}/zones"
-      $localzonepath      = "${dnsdir}/zones.rfc1918"
-      $defaultzonepath    = "${dnsdir}/named.conf.default-zones"
+      $localzonepath      = $facts['os']['name'] ? {
+        'Debian' => if versioncmp($facts['os']['release']['major'], '13') >= 0 { 'unmanaged' } else { "${dnsdir}/zones.rfc1918" },
+        default  => "${dnsdir}/zones.rfc1918",
+      }
+      $defaultzonepath    = $facts['os']['name'] ? {
+        'Debian' => if versioncmp($facts['os']['release']['major'], '13') >= 0 { 'unmanaged' } else { "${dnsdir}/named.conf.default-zones" },
+        default  => "${dnsdir}/named.conf.default-zones",
+      }
       $publicviewpath     = "${dnsdir}/zones.conf"
       $viewconfigpath     = "${dnsdir}/views"
       $dns_server_package = 'bind9'

--- a/metadata.json
+++ b/metadata.json
@@ -60,7 +60,8 @@
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "11",
-        "12"
+        "12",
+        "13"
       ]
     },
     {

--- a/spec/classes/dns_init_spec.rb
+++ b/spec/classes/dns_init_spec.rb
@@ -70,7 +70,9 @@ describe 'dns' do
       let(:localzonepath) do
         case facts[:os]['family']
         when 'Debian'
-          "#{etc_directory}/zones.rfc1918"
+          if facts[:os]['release']['major'] != '13'
+            "#{etc_directory}/zones.rfc1918"
+          end
         when 'RedHat'
           "#{etc_directory}/named.rfc1912.zones"
         end
@@ -79,7 +81,9 @@ describe 'dns' do
       let(:defaultzonepath) do
         case facts[:os]['family']
         when 'Debian'
-          "#{etc_directory}/named.conf.default-zones"
+          if facts[:os]['release']['major'] != '13'
+            "#{etc_directory}/named.conf.default-zones"
+          end
         end
       end
 


### PR DESCRIPTION
Debian 13 removed a bunch of default zones in favor of BIND 9 native
directive `empty-zones yes` (that is on by default).
