### PR TITLE
Drop puppet 7 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -28,7 +28,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 7.0.0 < 9.0.0"
+      "version_requirement": ">= 8.0.0 < 9.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Puppet 7 reached its EOL 7 in April 2025[1].

[1] https://help.puppet.com/core/8/Content/PuppetCore/platform_lifecycle.htm?Highlight=lifecycle