### PR TITLE
Fix filemode of the zonefile directory

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -61,7 +61,7 @@ class dns::config {
     ensure => directory,
     owner  => $dns::params::user,
     group  => $dns::params::group,
-    mode   => '0750',
+    mode   => $dns::zonefilepath_mode,
   }
 
   exec { 'create-rndc.key':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,6 +30,8 @@
 #   Name of the service
 # @param zonefilepath
 #   Directory containing zone files
+# @param zonefilepath_mode
+#   Mode of the directory containing zone files
 # @param localzonepath
 #   File holding local zones like RFC1912 or RFC1918 files.  The special value
 #   'unmanaged' can be used if one plans to create custom RFC1912/RFC1918 zones
@@ -159,6 +161,7 @@ class dns (
   Boolean $manage_service                                           = true,
   String $namedservicename                                          = $dns::params::namedservicename,
   Stdlib::Absolutepath $zonefilepath                                = $dns::params::zonefilepath,
+  Stdlib::Filemode $zonefilepath_mode                               = $dns::params::zonefilepath_mode,
   Variant[Enum['unmanaged'], Stdlib::Absolutepath] $localzonepath   = $dns::params::localzonepath,
   Variant[Enum['unmanaged'], Stdlib::Absolutepath] $defaultzonepath = $dns::params::defaultzonepath,
   Optional[Enum['only', 'first']] $forward                          = undef,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,6 +7,7 @@ class dns::params {
       $vardir             = '/var/cache/bind'
       $optionspath        = "${dnsdir}/named.conf.options"
       $zonefilepath       = "${vardir}/zones"
+      $zonefilepath_mode  = '0750'
       $localzonepath      = $facts['os']['name'] ? {
         'Debian' => if versioncmp($facts['os']['release']['major'], '13') >= 0 { 'unmanaged' } else { "${dnsdir}/zones.rfc1918" },
         default  => "${dnsdir}/zones.rfc1918",
@@ -41,6 +42,7 @@ class dns::params {
       $vardir             = '/var/named'
       $optionspath        = '/etc/named/options.conf'
       $zonefilepath       = "${vardir}/dynamic"
+      $zonefilepath_mode  = '0770'
       $localzonepath      = "${dnsdir}/named.rfc1912.zones"
       $defaultzonepath    = 'unmanaged'
       $publicviewpath     = "${dnsdir}/named/zones.conf"
@@ -66,6 +68,7 @@ class dns::params {
       $vardir             = '/usr/local/etc/namedb/working'
       $optionspath        = '/usr/local/etc/namedb/options.conf'
       $zonefilepath       = "${dnsdir}/dynamic"
+      $zonefilepath_mode  = '0750'
       $localzonepath      = 'unmanaged' # "${dnsdir}/master/empty.db"
       $defaultzonepath    = 'unmanaged'
       $publicviewpath     = "${dnsdir}/zones.conf"
@@ -89,6 +92,7 @@ class dns::params {
       $vardir             = '/var/named'
       $optionspath        = "${dnsdir}/named.options.conf"
       $zonefilepath       = "${vardir}/dynamic"
+      $zonefilepath_mode  = '0750'
       $localzonepath      = 'unmanaged' # "${dnsdir}/named.local.conf"
       $defaultzonepath    = 'unmanaged'
       $publicviewpath     = "${dnsdir}/zones.conf"

--- a/spec/classes/dns_init_spec.rb
+++ b/spec/classes/dns_init_spec.rb
@@ -109,6 +109,15 @@ describe 'dns' do
         end
       end
 
+      let(:zonefilepath_mode) do
+        case facts[:os]['family']
+        when 'RedHat'
+          '0770'
+        else
+          '0750'
+        end
+      end
+
       let(:service_name) { facts[:os]['family'] == 'Debian' ? 'bind9' : 'named' }
 
       describe 'with no custom parameters' do
@@ -162,7 +171,7 @@ describe 'dns' do
           verify_concat_fragment_exact_contents(catalogue, 'named.conf+10-main.dns', expected)
         end
 
-        it { should contain_file(zonefilepath).with_ensure('directory') }
+        it { should contain_file(zonefilepath).with_ensure('directory').with_mode(zonefilepath_mode) }
         it do
           should contain_exec('create-rndc.key')
             .with_command("#{sbin}/rndc-confgen -a -c #{rndc_key}")


### PR DESCRIPTION
In CentOS/RHEL the directory is created with mode 0770, instead of 0750.

Fixes: #288