### PR TITLE
Omit allow-recursion if empty

### DIFF
--- a/templates/options.conf.epp
+++ b/templates/options.conf.epp
@@ -33,7 +33,7 @@ listen-on { <%= $dns::listen_on %>; };
 listen-on-v6 { <%= $dns::listen_on_v6 %>; };
 <% } -%>
 
-<% if $dns::allow_recursion { -%>
+<% unless empty($dns::allow_recursion) { -%>
 allow-recursion { <%= join($dns::allow_recursion, '; ') %>; };
 <% } -%>
 


### PR DESCRIPTION
Fix the regression introduced by 04301a6a , which causes invalid allow-recursion option when dns::allow_recursion is empty.