### PR TITLE
remove white space from first zone config definition

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -25,7 +25,7 @@ class dns::config {
 
   concat::fragment { 'dns_zones+01-header.dns':
     target  => $dns::publicviewpath,
-    content => ' ',
+    content => '',
     order   => '01',
   }
 


### PR DESCRIPTION
minor cosmetic change validated against EL10 (EL 8 and 9 have the same config pattern ) and Ubuntu 24.04 (Debian works the same so not validated personally) 
strip white space from the first zone definition created in zones.conf caused by white space caused by concat input to ERB template