### PR TITLE
allow ACLS to be used in zone configuration options

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -8,9 +8,9 @@ class dns::config {
   }
 
   concat { $dns::publicviewpath:
-    owner        => root,
-    group        => $dns::params::group,
-    mode         => '0640',
+    owner => root,
+    group => $dns::params::group,
+    mode  => '0640',
   }
 
   if $dns::enable_views {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -11,7 +11,6 @@ class dns::config {
     owner        => root,
     group        => $dns::params::group,
     mode         => '0640',
-    validate_cmd => $validate_cmd,
   }
 
   if $dns::enable_views {

--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -20,6 +20,14 @@ options  {
         include "<%= scope.lookupvar('::dns::optionspath') %>";
 };
 
+<%- scope.lookupvar('::dns::acls').sort_by {|k, v| k}.each do |acl_name, acl_array| -%>
+acl "<%= acl_name %>"  {
+        <%- acl_array.sort.each do |subnet| -%>
+        <%= subnet %>;
+        <%- end -%>
+};
+<%- end -%>
+
 <% unless scope.lookupvar("::dns::enable_views") -%>
 <% if scope.lookupvar("::dns::localzonepath") != 'unmanaged' -%>
 include "<%= scope.lookupvar('::dns::localzonepath') %>";
@@ -28,14 +36,6 @@ include "<%= scope.lookupvar('::dns::localzonepath') %>";
 include "<%= scope.lookupvar('::dns::defaultzonepath') %>";
 <% end -%>
 <% end -%>
-
-<%- scope.lookupvar('::dns::acls').sort_by {|k, v| k}.each do |acl_name, acl_array| -%>
-acl "<%= acl_name %>"  {
-        <%- acl_array.sort.each do |subnet| -%>
-        <%= subnet %>;
-        <%- end -%>
-};
-<%- end -%>
 <%- if scope.lookupvar('::dns::additional_directives').any? -%>
 // additional directives
 <%- scope.lookupvar('::dns::additional_directives').each do |directive| -%>


### PR DESCRIPTION
--- suggested approach drop if a bad idea ----

being able to use ACLS' in zone definition such as allow-updates, allow-query, allow-tranfer is limited to internally defined ACLS (localnets and localhost) this maybe enough for a lot of use cases, but as ACL's and views become more important the ability to use ACLS within these parameters is important.

in order to use the ACL definition within puppet-dns the ACL's must be move higher up the template so they are available to be used in the zone definition.

this creates another problem that the validate process validates against temporary files from concat which means it will never pass validation because the required files it depends on are not generated at this point, until there is a better way to validate the ACL's it seems logical to remove validation on ACLS' 