### PR TITLE
add optional query-ipv6 parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -51,6 +51,8 @@
 #   The listen-on option
 # @param listen_on_v6
 #   The listen-on-v6 option
+# @param query_ipv6
+#   The query-ipv6 option. Set to 'no' to disable IPv6 queries.
 # @param recursion
 #   The recursion option
 # @param allow_recursion
@@ -169,6 +171,7 @@ class dns (
   Array[Stdlib::Fqdn] $rpz_zones                                    = [],
   Optional[String] $listen_on                                       = undef,
   Variant[String, Boolean] $listen_on_v6                            = 'any',
+  Optional[Enum['yes', 'no']] $query_ipv6                           = undef,
   Enum['yes', 'no'] $recursion                                      = 'yes',
   Array[String] $allow_recursion                                    = ['localnets', 'localhost'],
   Array[String] $allow_query                                        = ['any'],

--- a/templates/options.conf.epp
+++ b/templates/options.conf.epp
@@ -32,7 +32,6 @@ listen-on { <%= $dns::listen_on %>; };
 <% if $dns::listen_on_v6 { -%>
 listen-on-v6 { <%= $dns::listen_on_v6 %>; };
 <% } -%>
-
 <% if $dns::query_ipv6 { -%>
 query-ipv6 <%= $dns::query_ipv6 %>;
 <% } -%>

--- a/templates/options.conf.epp
+++ b/templates/options.conf.epp
@@ -33,6 +33,10 @@ listen-on { <%= $dns::listen_on %>; };
 listen-on-v6 { <%= $dns::listen_on_v6 %>; };
 <% } -%>
 
+<% if $dns::query_ipv6 { -%>
+query-ipv6 <%= $dns::query_ipv6 %>;
+<% } -%>
+
 <% unless empty($dns::allow_recursion) { -%>
 allow-recursion { <%= join($dns::allow_recursion, '; ') %>; };
 <% } -%>


### PR DESCRIPTION
more DNS servers are dual hosting on IPV6 and IPV4 certain conditions where an valid IPV6 address is not available on a bind server this causes a huge amount of noisy logs as ipv6 is consistently attempted (even with listen-on-ipv6 set to none) the answer in bind 9.18 is so use query-ipv6 parameter which will not lookup ipv6 records for name servers.
This is optional parameter so not breaking and will not be configured yes/no unless explicitly set, so is backward compatible and optional if you want to use it or not.