### PR TITLE
Revert "Add optional query-ipv6 parameter"

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -51,8 +51,6 @@
 #   The listen-on option
 # @param listen_on_v6
 #   The listen-on-v6 option
-# @param query_ipv6
-#   The query-ipv6 option. Set to 'no' to disable IPv6 queries.
 # @param recursion
 #   The recursion option
 # @param allow_recursion
@@ -171,7 +169,6 @@ class dns (
   Array[Stdlib::Fqdn] $rpz_zones                                    = [],
   Optional[String] $listen_on                                       = undef,
   Variant[String, Boolean] $listen_on_v6                            = 'any',
-  Optional[Enum['yes', 'no']] $query_ipv6                           = undef,
   Enum['yes', 'no'] $recursion                                      = 'yes',
   Array[String] $allow_recursion                                    = ['localnets', 'localhost'],
   Array[String] $allow_query                                        = ['any'],

--- a/templates/options.conf.epp
+++ b/templates/options.conf.epp
@@ -32,9 +32,6 @@ listen-on { <%= $dns::listen_on %>; };
 <% if $dns::listen_on_v6 { -%>
 listen-on-v6 { <%= $dns::listen_on_v6 %>; };
 <% } -%>
-<% if $dns::query_ipv6 { -%>
-query-ipv6 <%= $dns::query_ipv6 %>;
-<% } -%>
 
 <% unless empty($dns::allow_recursion) { -%>
 allow-recursion { <%= join($dns::allow_recursion, '; ') %>; };


### PR DESCRIPTION
TLDR: This reverts commit 065b550e378831e12d81c96d15a098f0c7149fe8.

Detail: 

Revert a feature that is present in bind 9.18 and later, initial testing of this feature was useful and worked, there was gaps in the implementation not fully considered. 

the feature was correctly introduced in https://gitlab.isc.org/isc-projects/bind9/-/merge_requests/9727 and while this was before EL10 release it was not earlier enough to make base that EL10 was built from.

There was no conditional verification of the feature implemented such as RHEL/Ubuntu/Version which in some situations could leave a broken feature in place (RHEL10)

A better approach is to revert this feature and remove the possibility (very edge case) of someone incorrectly using it, then re-implement it along with the raw-ipv6 parameter introduced in bind 9.19.19 as a pair with the correct verification of support and test cases associated with it. 

