### PR TITLE
Align module to currently supported releases and add Ubuntu 26.04

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,10 +10,12 @@ class dns::params {
       $zonefilepath_mode  = '0750'
       $localzonepath      = $facts['os']['name'] ? {
         'Debian' => if versioncmp($facts['os']['release']['major'], '13') >= 0 { 'unmanaged' } else { "${dnsdir}/zones.rfc1918" },
+        'Ubuntu' => if versioncmp($facts['os']['release']['major'], '26.04') >= 0 { 'unmanaged' } else { "${dnsdir}/zones.rfc1918" },
         default  => "${dnsdir}/zones.rfc1918",
       }
       $defaultzonepath    = $facts['os']['name'] ? {
         'Debian' => if versioncmp($facts['os']['release']['major'], '13') >= 0 { 'unmanaged' } else { "${dnsdir}/named.conf.default-zones" },
+        'Ubuntu' => if versioncmp($facts['os']['release']['major'], '26.04') >= 0 { 'unmanaged' } else { "${dnsdir}/named.conf.default-zones" },
         default  => "${dnsdir}/named.conf.default-zones",
       }
       $publicviewpath     = "${dnsdir}/zones.conf"
@@ -78,7 +80,7 @@ class dns::params {
       $user               = 'bind'
       $group              = 'bind'
       $rndcconfgen        = '/usr/local/sbin/rndc-confgen'
-      $named_checkconf    = '/usr/local/sbin/named-checkconf'
+      $named_checkconf    = '/usr/local/bin/named-checkconf'
       # The sysconfig settings are not relevant for FreeBSD
       $sysconfig_file     = undef
       $sysconfig_template = undef

--- a/metadata.json
+++ b/metadata.json
@@ -54,8 +54,8 @@
     {
       "operatingsystem": "Fedora",
       "operatingsystemrelease": [
-        "39",
-        "40"
+        "43",
+        "44"
       ]
     },
     {
@@ -71,13 +71,14 @@
       "operatingsystemrelease": [
         "20.04",
         "22.04",
-        "24.04"
+        "24.04",
+        "26.04"
       ]
     },
     {
       "operatingsystem": "FreeBSD",
       "operatingsystemrelease": [
-        "11"
+        "14"
       ]
     },
     {
@@ -86,7 +87,7 @@
     {
       "operatingsystem": "DragonFly",
       "operatingsystemrelease": [
-        "4"
+        "6"
       ]
     },
     {

--- a/spec/classes/dns_init_spec.rb
+++ b/spec/classes/dns_init_spec.rb
@@ -34,7 +34,7 @@ describe 'dns' do
         when 'Debian'
           facts[:os]['release']['major'] != '11' ? "/usr/bin/named-checkconf" : "/usr/sbin/named-checkconf"
         when 'FreeBSD'
-          '/usr/local/sbin/named-checkconf'
+          '/usr/local/bin/named-checkconf'
         else
           '/usr/sbin/named-checkconf'
         end
@@ -70,7 +70,11 @@ describe 'dns' do
       let(:localzonepath) do
         case facts[:os]['family']
         when 'Debian'
-          if facts[:os]['release']['major'] != '13'
+          if facts[:os]['name'] == 'Ubuntu'
+            if facts[:os]['release']['major'] < '26.04'
+              "#{etc_directory}/zones.rfc1918"
+            end
+          elsif facts[:os]['release']['major'] != '13'
             "#{etc_directory}/zones.rfc1918"
           end
         when 'RedHat'
@@ -81,7 +85,11 @@ describe 'dns' do
       let(:defaultzonepath) do
         case facts[:os]['family']
         when 'Debian'
-          if facts[:os]['release']['major'] != '13'
+          if facts[:os]['name'] == 'Ubuntu'
+            if facts[:os]['release']['major'] < '26.04'
+              "#{etc_directory}/named.conf.default-zones"
+            end
+          elsif facts[:os]['release']['major'] != '13'
             "#{etc_directory}/named.conf.default-zones"
           end
         end


### PR DESCRIPTION
Add Ubuntu 26.04 support 

align other operating systems to currently supported operating system versions

FreeBSD is listed as 14 only, 13 has only just gone EOL, but I suspect this will cause no problems and is just a little aggressive on removing.

Questions on Ubuntu 20.04 - only in Ubuntu Pro support, is this something the module supports
Dragonfly is listed as 4 - what's the target, should dragon fly even be there any more ?

Tested manually on Ubuntu 26.04 Fedora 43 and 44 also. 