### PR TITLE
support ipv6_query properly evaluating distro support of bind 9.20

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,7 +52,16 @@
 # @param listen_on_v6
 #   The listen-on-v6 option
 # @param query_ipv6
-#   The query-ipv6 option. Set to 'no' to disable IPv6 queries.
+#   The query-source-v6 option. Set to 'no' to disable IPv6 queries for upstream
+#   name server connections. This option is only available in BIND 9.20 or later.
+#   For older BIND versions, use `sysconfig_startup_options => '-4'` instead.
+#   WARNING: Using this parameter with BIND < 9.20 will cause configuration errors.
+# @param bind_9_20_compat
+#   Internal parameter that indicates whether the system has BIND 9.20 or later.
+#   This is automatically detected based on the operating system version. Do not
+#   override this parameter unless you know the BIND version differs from the
+#   OS-based detection. Changing this parameter incorrectly may result in
+#   invalid named.conf configuration.
 # @param recursion
 #   The recursion option
 # @param allow_recursion
@@ -172,6 +181,7 @@ class dns (
   Optional[String] $listen_on                                       = undef,
   Variant[String, Boolean] $listen_on_v6                            = 'any',
   Optional[Enum['yes', 'no']] $query_ipv6                           = undef,
+  Boolean $bind_9_20_compat                                         = $dns::params::bind_9_20_compat,
   Enum['yes', 'no'] $recursion                                      = 'yes',
   Array[String] $allow_recursion                                    = ['localnets', 'localhost'],
   Array[String] $allow_query                                        = ['any'],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -36,6 +36,15 @@ class dns::params {
       $sysconfig_disable_zone_checking = undef
 
       $dnssec_enable = undef
+
+      # Determine if BIND 9.20+ is available based on OS version
+      # BIND 9.20+ supports query-source-v6 none
+      # Ubuntu uses version format like "26.04" in os.release.major
+      $bind_9_20_compat = $facts['os']['name'] ? {
+        'Ubuntu' => versioncmp($facts['os']['release']['major'], '26.04') >= 0,
+        'Debian' => versioncmp($facts['os']['release']['major'], '13') >= 0,
+        default => false,
+      }
     }
     'RedHat': {
       $dnsdir             = '/etc'
@@ -62,6 +71,20 @@ class dns::params {
       $sysconfig_resolvconf_integration = undef
 
       $dnssec_enable = if versioncmp($facts['os']['release']['major'], '9') >= 0 { undef } else { 'yes' }
+
+      # Determine if BIND 9.20+ is available based on OS
+      # RHEL 11+ has BIND 9.20+, Fedora has it from 43+
+      $bind_9_20_compat = if $facts['os']['family'] == 'RedHat' {
+        if $facts['os']['name'] != 'Fedora' {
+          # Red Hat Enterprise Linux and variants (RHEL, CentOS, Rocky, Alma)
+          versioncmp($facts['os']['release']['major'], '11') >= 0
+        } else {
+          # Fedora
+          versioncmp($facts['os']['release']['major'], '43') >= 0
+        }
+      } else {
+        false
+      }
     }
     /^(FreeBSD|DragonFly)$/: {
       $dnsdir             = '/usr/local/etc/namedb'
@@ -86,6 +109,8 @@ class dns::params {
       $sysconfig_disable_zone_checking = undef
       $sysconfig_resolvconf_integration = undef
       $dnssec_enable = undef
+      # FreeBSD 14+ includes BIND 9.20+
+      $bind_9_20_compat = versioncmp($facts['os']['release']['major'], '14') >= 0
     }
     'Archlinux': {
       $dnsdir             = '/etc'
@@ -111,6 +136,9 @@ class dns::params {
       $sysconfig_resolvconf_integration = undef
 
       $dnssec_enable = undef
+
+      # Archlinux rolling release includes BIND 9.20+
+      $bind_9_20_compat = true
     }
     default: {
       fail ("Unsupported operating system family ${facts['os']['family']}")

--- a/metadata.json
+++ b/metadata.json
@@ -45,6 +45,14 @@
       ]
     },
     {
+      "operatingsystem": "RockyLinux",
+      "operatingsystemrelease": [
+        "8",
+        "9",
+        "10"
+      ]
+    },
+    {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "9",
@@ -54,14 +62,13 @@
     {
       "operatingsystem": "Fedora",
       "operatingsystemrelease": [
-        "39",
-        "40"
+        "43",
+        "44"
       ]
     },
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "11",
         "12",
         "13"
       ]
@@ -71,13 +78,14 @@
       "operatingsystemrelease": [
         "20.04",
         "22.04",
-        "24.04"
+        "24.04",
+        "26.04"
       ]
     },
     {
       "operatingsystem": "FreeBSD",
       "operatingsystemrelease": [
-        "11"
+        "14"
       ]
     },
     {

--- a/spec/classes/dns_init_spec.rb
+++ b/spec/classes/dns_init_spec.rb
@@ -593,6 +593,47 @@ describe 'dns' do
           }
         end
       end
+
+      context 'query_ipv6 (BIND 9.20+ only)' do
+        # Only test on OSes known to have BIND 9.20+
+        # Match the logic from params.pp: check os.family + os.name combinations
+        # The test framework (on_supported_os) already filters by version from metadata.json
+        # Use Puppet::Util::Package.versioncmp for version comparison (mirrors Puppet's versioncmp function)
+        supported_os = case os_facts[:os]['family']
+                       when 'Debian'
+                         case os_facts[:os]['name']
+                         when 'Ubuntu'
+                           Puppet::Util::Package.versioncmp(os_facts[:os]['release']['major'], '26.04') >= 0
+                         when 'Debian'
+                           Puppet::Util::Package.versioncmp(os_facts[:os]['release']['major'], '13') >= 0
+                         else
+                           false
+                         end
+                       when 'RedHat'
+                         # RHEL 11+ (but not Fedora)
+                         if os_facts[:os]['name'] == 'Fedora'
+                           Puppet::Util::Package.versioncmp(os_facts[:os]['release']['major'], '43') >= 0
+                         else
+                           Puppet::Util::Package.versioncmp(os_facts[:os]['release']['major'], '11') >= 0
+                         end
+                       else
+                         false
+                       end
+
+        let(:params) { {:query_ipv6 => 'no'} }
+
+        if supported_os
+          it 'should include query-source-v6 none' do
+            verify_concat_fragment_contents(catalogue, 'options.conf+10-main.dns', [
+              'query-source-v6 none;',
+            ])
+          end
+        else
+          it 'should not include query-source-v6' do
+            is_expected.to contain_concat_fragment('options.conf+10-main.dns').without_content('/query-source-v6/')
+          end
+        end
+      end
     end
   end
 end

--- a/templates/options.conf.epp
+++ b/templates/options.conf.epp
@@ -32,8 +32,11 @@ listen-on { <%= $dns::listen_on %>; };
 <% if $dns::listen_on_v6 { -%>
 listen-on-v6 { <%= $dns::listen_on_v6 %>; };
 <% } -%>
-<% if $dns::query_ipv6 { -%>
-query-ipv6 <%= $dns::query_ipv6 %>;
+<% if $dns::query_ipv6 and $dns::bind_9_20_compat { -%>
+query-source-v6 none;
+<% } elsif $dns::query_ipv6 and !$dns::bind_9_20_compat { -%>
+<%# WARNING: query-source-v6 requires BIND 9.20+ %>
+<%# This system may not support the query-source-v6 option %>
 <% } -%>
 
 <% unless empty($dns::allow_recursion) { -%>


### PR DESCRIPTION
this work is what should have been submitted for #296 while it technically works it was a sloppy implementation, and in certain situations would have broken bind config if enabled (not a real problem as it could just be disabled with the parameter).

This work correctly evaluates distributions that are compatible with current supported versions of bind (9.19 onwards - as 9.18 is EOL June 2026) 

This updates baselines functional drift from 9.20 onwards anchoring on https://gitlab.isc.org/isc-projects/bind9/-/merge_requests/9727 changes. 

9.19 while supported is mostly 9.18 functionality with only minor parameter drift and all latest major distribution releases supported by this module ship with 9.20.

Test cases have been updated to only test 9.20 functionality against these distributions and future ones leaving backward compatibility for pre 9.20 distributions that are still in support (EL 8-9-10 / Ubuntu 20.04 / 22.04 / 24.04) until they go EOL. 

This PR also updates the metadata.json of supported OS's to align to actually current distributions, ensuring tests run against the correct OS's.  This update has also been shipped as a stand alone PR https://github.com/theforeman/puppet-dns/pull/302 should this not be merged in, it will at least bring the module in line with current supported versions of the OS's it supports, if this update is merged, I will close https://github.com/theforeman/puppet-dns/pull/302 

There is logic in the version evaluation for EL11 - while this is not released yet (and is not included in the metadata.json) it made sense to include the logic for it to both allow for testing against the Alpha releases (which contain Bind 9.20) and have it ready for release when RHEL 11 actually is released without having to change the logic, enable the OS in metadata.json and it's ready to go.

Tests pass locally and the functionality is checked as ignored on EL10, but applied on Ubuntu 26.04 and Debian 13