### PR TITLE
Preserve address match list order in named.conf

### DIFF
--- a/spec/classes/dns_init_spec.rb
+++ b/spec/classes/dns_init_spec.rb
@@ -374,12 +374,44 @@ describe 'dns' do
         ])}
       end
 
+      describe 'with acls whose order must be preserved' do
+        let(:params) { {:acls => { 'trusted_nets' => [ '!192.0.2.5', '192.0.2.0/24', '10.0.0.0/8' ] } } }
+
+        it { verify_concat_fragment_contents(catalogue, 'named.conf+10-main.dns', [
+          'acl "trusted_nets"  {',
+          '        !192.0.2.5;',
+          '        192.0.2.0/24;',
+          '        10.0.0.0/8;',
+          '};',
+        ])}
+      end
+
       describe 'with statistics channels' do
         let(:params) { { :statistics_channels => { '*' => { 'port' => 8053, 'allowed_addresses' => [ '127.0.0.0/8' ] } } } }
 
         it { verify_concat_fragment_contents(catalogue, 'named.conf+10-main.dns', [
           'statistics-channels  {',
           '        inet * port 8053 allow { 127.0.0.0/8; };',
+          '};',
+        ])}
+      end
+
+      describe 'with statistics channels allowed_addresses order preserved' do
+        let(:params) { { :statistics_channels => { '*' => { 'port' => 8053, 'allowed_addresses' => [ '!192.0.2.5', '192.0.2.0/24', '10.0.0.0/8' ] } } } }
+
+        it { verify_concat_fragment_contents(catalogue, 'named.conf+10-main.dns', [
+          'statistics-channels  {',
+          '        inet * port 8053 allow { !192.0.2.5; 192.0.2.0/24; 10.0.0.0/8; };',
+          '};',
+        ])}
+      end
+
+      describe 'with controls allowed_addresses order preserved' do
+        let(:params) { { :controls => { '127.0.0.1' => { 'port' => 953, 'allowed_addresses' => [ '!192.0.2.5', '192.0.2.0/24', '10.0.0.0/8' ], 'keys' => [ 'rndc-key' ] } } } }
+
+        it { verify_concat_fragment_contents(catalogue, 'named.conf+10-main.dns', [
+          'controls  {',
+          '        inet 127.0.0.1 port 953 allow { !192.0.2.5; 192.0.2.0/24; 10.0.0.0/8; } keys { "rndc-key"; };',
           '};',
         ])}
       end

--- a/templates/named.conf.erb
+++ b/templates/named.conf.erb
@@ -4,14 +4,14 @@ include "<%= scope.lookupvar('::dns::rndckeypath') %>";
 
 controls  {
 <%- scope.lookupvar('::dns::controls').sort_by {|k, v| k}.each do |control_ip, control_hash| -%>
-        inet <%= control_ip %> port <%= control_hash['port'] %> allow { <% control_hash['allowed_addresses'].sort.each do |address| %><%= address %>; <% end %>} keys { <% control_hash['keys'].sort.each do |key| %>"<%= key %>"; <% end %>};
+        inet <%= control_ip %> port <%= control_hash['port'] %> allow { <% control_hash['allowed_addresses'].each do |address| %><%= address %>; <% end %>} keys { <% control_hash['keys'].each do |key| %>"<%= key %>"; <% end %>};
 <%- end -%>
 };
 <%- if scope.lookupvar('::dns::statistics_channels').any? -%>
 
 statistics-channels  {
 <%- scope.lookupvar('::dns::statistics_channels').sort_by {|k, v| k}.each do |stats_ip, stats_hash| -%>
-        inet <%= stats_ip %> port <%= stats_hash['port'] %> allow { <% stats_hash['allowed_addresses'].sort.each do |address| %><%= address %>; <% end %>};
+        inet <%= stats_ip %> port <%= stats_hash['port'] %> allow { <% stats_hash['allowed_addresses'].each do |address| %><%= address %>; <% end %>};
 <%- end -%>
 };
 <%- end -%>
@@ -31,7 +31,7 @@ include "<%= scope.lookupvar('::dns::defaultzonepath') %>";
 
 <%- scope.lookupvar('::dns::acls').sort_by {|k, v| k}.each do |acl_name, acl_array| -%>
 acl "<%= acl_name %>"  {
-        <%- acl_array.sort.each do |subnet| -%>
+        <%- acl_array.each do |subnet| -%>
         <%= subnet %>;
         <%- end -%>
 };


### PR DESCRIPTION
Preserve address match list order in named.conf, since it's significant in BIND.

Fixes https://github.com/theforeman/puppet-dns/issues/272
